### PR TITLE
fix: add write-through persistence to SettingsManager

### DIFF
--- a/CallTranscription/CallTranscription.entitlements
+++ b/CallTranscription/CallTranscription.entitlements
@@ -8,7 +8,5 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
-	<key>com.apple.security.audio-input</key>
-	<true/>
 </dict>
 </plist>

--- a/CallTranscription/Settings/SettingsManager.swift
+++ b/CallTranscription/Settings/SettingsManager.swift
@@ -24,6 +24,7 @@ public final class SettingsManager: ObservableObject {
     @Published public var captureMicrophone: Bool
 
     private let userDefaults: UserDefaults
+    private var cancellables = Set<AnyCancellable>()
 
     public init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
@@ -46,6 +47,43 @@ public final class SettingsManager: ObservableObject {
         } else {
             self.captureMicrophone = Self.defaultCaptureMicrophone
         }
+
+        // Set up observers to persist changes to UserDefaults
+        setupPersistence()
+    }
+
+    private func setupPersistence() {
+        // Persist outputFolder changes
+        $outputFolder
+            .dropFirst() // Skip initial value
+            .sink { [weak self] newValue in
+                self?.userDefaults.set(newValue, forKey: Keys.outputFolder)
+            }
+            .store(in: &cancellables)
+
+        // Persist postRecordingScript changes
+        $postRecordingScript
+            .dropFirst() // Skip initial value
+            .sink { [weak self] newValue in
+                self?.userDefaults.set(newValue, forKey: Keys.postRecordingScript)
+            }
+            .store(in: &cancellables)
+
+        // Persist captureSystemAudio changes
+        $captureSystemAudio
+            .dropFirst() // Skip initial value
+            .sink { [weak self] newValue in
+                self?.userDefaults.set(newValue, forKey: Keys.captureSystemAudio)
+            }
+            .store(in: &cancellables)
+
+        // Persist captureMicrophone changes
+        $captureMicrophone
+            .dropFirst() // Skip initial value
+            .sink { [weak self] newValue in
+                self?.userDefaults.set(newValue, forKey: Keys.captureMicrophone)
+            }
+            .store(in: &cancellables)
     }
 
     // Path expansion utilities

--- a/CallTranscriptionTests/Settings/SettingsManagerTests.swift
+++ b/CallTranscriptionTests/Settings/SettingsManagerTests.swift
@@ -243,4 +243,86 @@ final class SettingsManagerTests: XCTestCase {
         XCTAssertEqual(microphoneChanges.first, false,
                       "Microphone changes should be published")
     }
+
+    // MARK: - Write-Through Persistence Tests
+
+    func testOutputFolderChangeWritesToUserDefaults() async {
+        let newPath = "/Users/test/NewFolder"
+        settingsManager.outputFolder = newPath
+
+        // Give Combine pipeline time to process
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+
+        // Verify it was written to UserDefaults
+        let storedValue = testUserDefaults.string(forKey: "outputFolder")
+        XCTAssertEqual(storedValue, newPath,
+                      "Output folder changes should be written to UserDefaults")
+    }
+
+    func testPostRecordingScriptChangeWritesToUserDefaults() async {
+        let newScript = "/usr/local/bin/new-script.sh"
+        settingsManager.postRecordingScript = newScript
+
+        // Give Combine pipeline time to process
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+
+        // Verify it was written to UserDefaults
+        let storedValue = testUserDefaults.string(forKey: "postRecordingScript")
+        XCTAssertEqual(storedValue, newScript,
+                      "Post-recording script changes should be written to UserDefaults")
+    }
+
+    func testCaptureSystemAudioChangeWritesToUserDefaults() async {
+        settingsManager.captureSystemAudio = false
+
+        // Give Combine pipeline time to process
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+
+        // Verify it was written to UserDefaults
+        let storedValue = testUserDefaults.bool(forKey: "captureSystemAudio")
+        XCTAssertFalse(storedValue,
+                      "Capture system audio changes should be written to UserDefaults")
+    }
+
+    func testCaptureMicrophoneChangeWritesToUserDefaults() async {
+        settingsManager.captureMicrophone = false
+
+        // Give Combine pipeline time to process
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+
+        // Verify it was written to UserDefaults
+        let storedValue = testUserDefaults.bool(forKey: "captureMicrophone")
+        XCTAssertFalse(storedValue,
+                      "Capture microphone changes should be written to UserDefaults")
+    }
+
+    func testMultipleChangesAllPersist() async {
+        // Make multiple changes
+        settingsManager.outputFolder = "/new/output"
+        settingsManager.postRecordingScript = "/new/script.sh"
+        settingsManager.captureSystemAudio = false
+        settingsManager.captureMicrophone = false
+
+        // Give Combine pipeline time to process
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+
+        // Verify all were written
+        XCTAssertEqual(testUserDefaults.string(forKey: "outputFolder"), "/new/output")
+        XCTAssertEqual(testUserDefaults.string(forKey: "postRecordingScript"), "/new/script.sh")
+        XCTAssertFalse(testUserDefaults.bool(forKey: "captureSystemAudio"))
+        XCTAssertFalse(testUserDefaults.bool(forKey: "captureMicrophone"))
+    }
+
+    func testChangesPersistToNewInstance() async {
+        // Make a change
+        settingsManager.outputFolder = "/persistent/folder"
+
+        // Give Combine pipeline time to process
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+
+        // Create new instance - should read the persisted value
+        let newManager = SettingsManager(userDefaults: testUserDefaults)
+        XCTAssertEqual(newManager.outputFolder, "/persistent/folder",
+                      "Changes should persist to new instances via UserDefaults")
+    }
 }


### PR DESCRIPTION
## Summary
Fixes critical issue where SettingsManager was only reading from UserDefaults but never writing changes back, making it effectively read-only.

## Problem
In PR #34, SettingsManager was implemented with @Published properties that read from UserDefaults on initialization, but changes to these properties were never persisted back to UserDefaults. This meant:
- UI changes via @AppStorage worked (they persist directly)
- Programmatic changes via SettingsManager did NOT persist
- Created architectural inconsistency

## Solution
- Added Combine publishers that observe all @Published properties
- Changes are automatically written to UserDefaults via sink handlers
- Used dropFirst() to skip initial values and avoid redundant writes
- Proper memory management with weak self and cancellables

## Additional Fixes
- Removed duplicate `com.apple.security.audio-input` entitlement (only need `com.apple.security.device.audio-input`)

## Test Coverage
Added 6 new tests for write-through persistence:
- testOutputFolderChangeWritesToUserDefaults
- testPostRecordingScriptChangeWritesToUserDefaults
- testCaptureSystemAudioChangeWritesToUserDefaults
- testCaptureMicrophoneChangeWritesToUserDefaults
- testMultipleChangesAllPersist
- testChangesPersistToNewInstance

All 23 SettingsManagerTests passing (81 total tests across project).

## Review Feedback
Addresses CRITICAL feedback from PR #34 review: https://github.com/rygn-dev/olive-call-transcription/pull/34#issuecomment-3661952856