### PR TITLE
fix: Revert menu bar icons to SF Symbols

### DIFF
--- a/CallTranscription/CallTranscriptionApp.swift
+++ b/CallTranscription/CallTranscriptionApp.swift
@@ -18,13 +18,14 @@ struct CallTranscriptionApp: App {
                 .environmentObject(settingsManager)
         } label: {
             // Show different icon based on recording state
-            // Use custom SVG: monochrome when inactive, color when recording/paused
-            if appState.isRecording || appState.isPaused {
-                Image("MenuBarIconRecording")
-                    .renderingMode(.original) // Preserve colors
+            if appState.isPaused {
+                Image(systemName: "pause.circle.fill")
+                    .foregroundColor(.orange)
+            } else if appState.isRecording {
+                Image(systemName: "record.circle")
+                    .foregroundColor(.red)
             } else {
-                Image("MenuBarIconInactive")
-                    .renderingMode(.template) // Allow system tinting
+                Image(systemName: "stop.circle")
             }
         }
 


### PR DESCRIPTION
## Summary

Reverts menu bar icons from custom SVGs back to SF Symbols for immediate functionality.

## Why

The custom SVG icons from PR #66 don't load due to XcodeGen not properly handling the Assets.xcassets resource (issue #67). This causes console errors and missing icons in the menu bar.

## Changes

Replaced custom image assets with SF Symbols:
- **Inactive**: `stop.circle` (gray)
- **Recording**: `record.circle` (red)  
- **Paused**: `pause.circle.fill` (orange)

## Impact

✅ Menu bar icons now work immediately without manual configuration
✅ No more console errors about missing images
✅ Custom SVG assets remain in the project for future use (once #67 is resolved)

This is a temporary fix until the manual Xcode configuration in #67 is completed.