### PR TITLE
feat: Add comprehensive user and developer documentation (Issue #24)

### DIFF
--- a/CallTranscriptionTests/DocumentationTests.swift
+++ b/CallTranscriptionTests/DocumentationTests.swift
@@ -1,0 +1,199 @@
+import XCTest
+import Foundation
+
+/// Tests that verify comprehensive documentation exists and is complete
+final class DocumentationTests: XCTestCase {
+
+    // MARK: - README Completeness Tests
+
+    func testREADMEExists() throws {
+        let readmePath = projectRoot.appendingPathComponent("README.md")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: readmePath.path),
+            "README.md must exist in repository root"
+        )
+    }
+
+    func testREADMEIncludesProjectDescription() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.contains("Olive") || readmeContent.lowercased().contains("call transcription"),
+            "README must include project description"
+        )
+    }
+
+    func testREADMEIncludesRequirements() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("requirement") || readmeContent.lowercased().contains("macos"),
+            "README must include system requirements (macOS version)"
+        )
+    }
+
+    func testREADMEIncludesBuildInstructions() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("build") || readmeContent.lowercased().contains("xcode"),
+            "README must include build instructions"
+        )
+    }
+
+    func testREADMEIncludesUsageInstructions() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("usage") || readmeContent.lowercased().contains("how to"),
+            "README must include usage instructions"
+        )
+    }
+
+    // MARK: - User Documentation Tests
+
+    func testUserDocumentationExplainsInstallation() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("install") || readmeContent.lowercased().contains("setup"),
+            "Documentation must explain installation process"
+        )
+    }
+
+    func testUserDocumentationExplainsPermissions() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("permission") || readmeContent.lowercased().contains("privacy"),
+            "Documentation must explain required permissions"
+        )
+    }
+
+    func testUserDocumentationExplainsFeatures() throws {
+        let readmeContent = try readREADME()
+        let hasRecording = readmeContent.lowercased().contains("record")
+        let hasTranscription = readmeContent.lowercased().contains("transcri")
+        XCTAssertTrue(
+            hasRecording && hasTranscription,
+            "Documentation must explain core features (recording, transcription)"
+        )
+    }
+
+    func testUserDocumentationExplainsSettings() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("setting") || readmeContent.lowercased().contains("configuration"),
+            "Documentation must explain available settings"
+        )
+    }
+
+    func testUserDocumentationIncludesTroubleshooting() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("troubleshoot") || readmeContent.lowercased().contains("common") && readmeContent.lowercased().contains("error"),
+            "Documentation must include troubleshooting section"
+        )
+    }
+
+    // MARK: - Developer Documentation Tests
+
+    func testDeveloperDocumentationExplainsArchitecture() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("architecture"),
+            "Developer documentation must explain or reference architecture"
+        )
+    }
+
+    func testDeveloperDocumentationExplainsHowToBuild() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("build") || readmeContent.lowercased().contains("compile"),
+            "Developer documentation must explain build process"
+        )
+    }
+
+    func testDeveloperDocumentationExplainsHowToTest() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("test") || readmeContent.lowercased().contains("tdd"),
+            "Developer documentation must explain testing approach"
+        )
+    }
+
+    func testDeveloperDocumentationExplainsHowToContribute() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.lowercased().contains("contribut") || readmeContent.lowercased().contains("development"),
+            "Developer documentation must explain contribution process"
+        )
+    }
+
+    func testDeveloperDocumentationReferencesArchitectureMd() throws {
+        let readmeContent = try readREADME()
+        XCTAssertTrue(
+            readmeContent.contains("architecture.md"),
+            "Developer documentation must reference architecture.md"
+        )
+    }
+
+    // MARK: - Troubleshooting Guide Tests
+
+    func testTroubleshootingCoversCommonErrors() throws {
+        let readmeContent = try readREADME()
+        // Check for troubleshooting section with error-related content
+        let hasTroubleshooting = readmeContent.lowercased().contains("troubleshoot")
+        let hasErrors = readmeContent.lowercased().contains("error") || readmeContent.lowercased().contains("problem")
+        XCTAssertTrue(
+            hasTroubleshooting && hasErrors,
+            "Troubleshooting guide must cover common errors"
+        )
+    }
+
+    func testTroubleshootingCoversPermissionIssues() throws {
+        let readmeContent = try readREADME()
+        let hasTroubleshooting = readmeContent.lowercased().contains("troubleshoot")
+        let hasPermissions = readmeContent.lowercased().contains("permission")
+        XCTAssertTrue(
+            hasTroubleshooting && hasPermissions,
+            "Troubleshooting guide must cover permission issues"
+        )
+    }
+
+    func testTroubleshootingCoversAudioCaptureIssues() throws {
+        let readmeContent = try readREADME()
+        let hasTroubleshooting = readmeContent.lowercased().contains("troubleshoot")
+        let hasAudio = readmeContent.lowercased().contains("audio") || readmeContent.lowercased().contains("recording")
+        XCTAssertTrue(
+            hasTroubleshooting && hasAudio,
+            "Troubleshooting guide must cover audio capture issues"
+        )
+    }
+
+    // MARK: - Helper Methods
+
+    private var projectRoot: URL {
+        // Try getting from source file path first (if absolute)
+        let sourceFile = #file
+        if sourceFile.hasPrefix("/") {
+            // Absolute path - we can use it
+            var url = URL(fileURLWithPath: sourceFile)
+            url.deleteLastPathComponent() // Remove DocumentationTests.swift
+            url.deleteLastPathComponent() // Remove CallTranscriptionTests
+            return url
+        }
+
+        // Fallback: navigate up from current directory
+        var fallbackURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        while fallbackURL.path != "/" {
+            let testPath = fallbackURL.appendingPathComponent("README.md")
+            if FileManager.default.fileExists(atPath: testPath.path) {
+                return fallbackURL
+            }
+            fallbackURL.deleteLastPathComponent()
+        }
+
+        // Last resort: assume we're in the project directory
+        return URL(fileURLWithPath: "/Users/dalton/Dev/olive-call-transcription")
+    }
+
+    private func readREADME() throws -> String {
+        let readmePath = projectRoot.appendingPathComponent("README.md")
+        return try String(contentsOf: readmePath, encoding: .utf8)
+    }
+}

--- a/CallTranscriptionTests/DocumentationTests.swift
+++ b/CallTranscriptionTests/DocumentationTests.swift
@@ -168,28 +168,16 @@ final class DocumentationTests: XCTestCase {
     // MARK: - Helper Methods
 
     private var projectRoot: URL {
-        // Try getting from source file path first (if absolute)
-        let sourceFile = #file
-        if sourceFile.hasPrefix("/") {
-            // Absolute path - we can use it
-            var url = URL(fileURLWithPath: sourceFile)
-            url.deleteLastPathComponent() // Remove DocumentationTests.swift
-            url.deleteLastPathComponent() // Remove CallTranscriptionTests
-            return url
-        }
+        // Use source file path (#file) to locate project root
+        // This works reliably in Xcode and command-line builds
+        let sourceFile = #filePath
+        var url = URL(fileURLWithPath: sourceFile)
 
-        // Fallback: navigate up from current directory
-        var fallbackURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        while fallbackURL.path != "/" {
-            let testPath = fallbackURL.appendingPathComponent("README.md")
-            if FileManager.default.fileExists(atPath: testPath.path) {
-                return fallbackURL
-            }
-            fallbackURL.deleteLastPathComponent()
-        }
+        // Navigate up from CallTranscriptionTests/DocumentationTests.swift to project root
+        url.deleteLastPathComponent() // Remove DocumentationTests.swift
+        url.deleteLastPathComponent() // Remove CallTranscriptionTests directory
 
-        // Last resort: assume we're in the project directory
-        return URL(fileURLWithPath: "/Users/dalton/Dev/olive-call-transcription")
+        return url
     }
 
     private func readREADME() throws -> String {

--- a/Olive.xcodeproj/project.pbxproj
+++ b/Olive.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		45F7253F3E3CA0D9887D15D7 /* ConsentDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106F623C49C22E447C38C0A5 /* ConsentDialogView.swift */; };
 		47CE13A6B71D647D54BD84DE /* CallTranscriptionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0657F96D2E40E3389E766B07 /* CallTranscriptionError.swift */; };
 		4DD997AC21F137568A88FD79 /* ShellScriptExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1235EA4033020F640692F879 /* ShellScriptExecutorTests.swift */; };
+		6256204984916781E48DF883 /* DocumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9E66C5100147BA741122CD /* DocumentationTests.swift */; };
 		667A0C69A41F1FDFE6BEF844 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F014C487C1E73F33DAB317CD /* MenuBarView.swift */; };
 		6D6D093E40D6B3DCEA49FCC0 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7A54A678DA5B048E710A0E /* SettingsView.swift */; };
 		6E8F1A28DF73EB8F094B72E9 /* SystemAudioCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48956BE463D64897BAACB155 /* SystemAudioCapture.swift */; };
@@ -85,6 +86,7 @@
 		5762BC9ACB64399002352CBC /* TranscriptWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptWriterTests.swift; sourceTree = "<group>"; };
 		661EF16D5EE1366035BC2141 /* MicrophoneCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneCaptureTests.swift; sourceTree = "<group>"; };
 		680A84F158E14BBD21E703A8 /* RecordingSessionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionCoordinatorTests.swift; sourceTree = "<group>"; };
+		6A9E66C5100147BA741122CD /* DocumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentationTests.swift; sourceTree = "<group>"; };
 		6B18C6601268A155FA1A1829 /* CallTranscriptionTests.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CallTranscriptionTests.entitlements; sourceTree = "<group>"; };
 		7803A35D6B08C16D4B169935 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		7E7A54A678DA5B048E710A0E /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -285,6 +287,7 @@
 				7803A35D6B08C16D4B169935 /* AppStateTests.swift */,
 				143FA64342B9D7E610046B7E /* CallTranscriptionErrorTests.swift */,
 				6B18C6601268A155FA1A1829 /* CallTranscriptionTests.entitlements */,
+				6A9E66C5100147BA741122CD /* DocumentationTests.swift */,
 				C1BA3BDC46457393389C4602 /* EndToEndIntegrationTests.swift */,
 				C1EC3A1B8C79D0543AB06927 /* PerformanceAndMemoryTests.swift */,
 				AAB7B8EFF1D85E68D2829EB8 /* ProjectConfigurationTests.swift */,
@@ -459,6 +462,7 @@
 				90F9DC491B4E83FD407B502D /* AudioMixerTests.swift in Sources */,
 				B3FD3C7687B0155E2E51ADC5 /* CallTranscriptionErrorTests.swift in Sources */,
 				FF46D0CEF84D6571340AC619 /* ConsentDialogViewTests.swift in Sources */,
+				6256204984916781E48DF883 /* DocumentationTests.swift in Sources */,
 				CE2CB29FEAF80F02292FDCD3 /* EndToEndIntegrationTests.swift in Sources */,
 				355A16907F2EF67A79BA08E4 /* MenuBarViewTests.swift in Sources */,
 				ECAC234A1784BE93CA802A10 /* MicrophoneCaptureTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Olive is a macOS menu bar application that records and transcribes audio from bo
 
 ## Requirements
 
-- **macOS 26.0 or later** (required for SpeechTranscriber API)
+- **macOS 26.0 or later** (required for SpeechTranscriber API - currently in beta/developer preview)
 - **Swift 6** / SwiftUI
 - **Xcode 16+** for building from source
 - **XcodeGen** for project generation (optional, for development)
@@ -209,7 +209,7 @@ All features follow strict TDD methodology:
 2. Implement minimal code to pass tests
 3. Refactor while keeping tests green
 
-See [CLAUDE.md](CLAUDE.md) for TDD requirements.
+See [claude.md](claude.md) for TDD requirements.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,326 @@
 # Olive: Call Transcription
 
-Olive is a macOS application for recording and transcribing calls with automatic silence detection and pause functionality.
+Olive is a macOS menu bar application that records and transcribes audio from both sides of calls (Zoom, Teams, etc.) using Apple's native Speech framework. Features automatic silence detection, pause functionality, and non-invasive audio capture.
 
-## Development Setup
+## Table of Contents
 
-### Visual Assets Configuration
+- [Features](#features)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Settings](#settings)
+- [Permissions](#permissions)
+- [Development](#development)
+- [Architecture](#architecture)
+- [Testing](#testing)
+- [Contributing](#contributing)
+- [Troubleshooting](#troubleshooting)
 
-After cloning the repository, you need to manually add visual assets to the Xcode project (XcodeGen doesn't fully support Icon Composer packages):
+## Features
 
-1. Open `Olive.xcodeproj` in Xcode
-2. Drag `CallTranscription/icon.icon` into the project navigator
-3. Drag `CallTranscription/Assets.xcassets` into the project navigator
-4. Verify both are listed in the target's "Copy Bundle Resources" build phase
-5. Build and run to verify assets load correctly
+- **Dual Audio Recording**: Captures both system audio (what you hear) and microphone input (what you say)
+- **Real-time Transcription**: Uses Apple's SpeechTranscriber API for on-device transcription
+- **Automatic Silence Detection**: Pauses transcription during silence periods to save processing
+- **Menu Bar Interface**: Minimal, always-accessible controls
+- **Post-Recording Automation**: Execute shell scripts or shortcuts after recording stops
+- **Privacy-First**: All transcription happens on-device using Apple's Speech framework
 
-**Note:** Do not run `xcodegen generate` after manually adding assets, as it will remove them. The `project.yml` file documents the intended resource configuration for future XcodeGen updates.
+## Requirements
+
+- **macOS 26.0 or later** (required for SpeechTranscriber API)
+- **Swift 6** / SwiftUI
+- **Xcode 16+** for building from source
+- **XcodeGen** for project generation (optional, for development)
+
+## Installation
+
+### From Source
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/rygn-dev/olive-call-transcription.git
+   cd olive-call-transcription
+   ```
+
+2. Configure visual assets (one-time setup):
+   ```bash
+   open Olive.xcodeproj
+   ```
+   Then drag these files into the Xcode project navigator:
+   - `CallTranscription/icon.icon`
+   - `CallTranscription/Assets.xcassets`
+
+   Verify both are listed in the CallTranscription target's "Copy Bundle Resources" build phase.
+
+3. Build and run in Xcode (⌘R)
+
+**Note**: Do not run `xcodegen generate` after manually adding visual assets, as it will remove them.
+
+## Usage
+
+### Starting a Recording
+
+1. Click the Olive menu bar icon
+2. Click "Start Recording"
+3. The app captures both system audio and microphone input
+4. Transcription happens in real-time using on-device Speech recognition
+
+### Stopping a Recording
+
+1. Click the Olive menu bar icon again
+2. Click "Stop Recording"
+3. Transcript is automatically saved to your configured output folder
+4. Optional post-recording script or shortcut executes
+
+### Transcript Files
+
+Transcripts are saved as `.txt` files in your configured output folder with timestamps:
+```
+Transcript_2025-01-15_14-30-00.txt
+```
+
+## Settings
+
+Access settings by clicking "Settings..." in the menu bar.
+
+### Output Folder
+
+Choose where transcript files are saved. Click "Browse..." to select a folder.
+
+### Audio Sources
+
+- **System Audio**: Captures audio from applications (e.g., Zoom, Teams)
+- **Microphone**: Captures your voice input
+
+Both can be enabled independently or together.
+
+### Post-Recording Script
+
+Optionally execute a shell script after each recording completes. Useful for:
+- Uploading transcripts to cloud storage
+- Processing transcripts with custom tools
+- Triggering notifications
+
+## Permissions
+
+Olive requires the following macOS permissions:
+
+### Microphone Access
+
+**Required for**: Recording your voice during calls
+
+**How to grant**:
+1. System Settings → Privacy & Security → Microphone
+2. Enable "Olive"
+
+### Speech Recognition
+
+**Required for**: Transcribing audio to text
+
+**How to grant**:
+1. System Settings → Privacy & Security → Speech Recognition
+2. Enable "Olive"
+
+The app will prompt for these permissions on first launch.
+
+## Development
+
+### Project Setup
+
+1. Install Xcode 16+ from the Mac App Store
+
+2. Clone the repository:
+   ```bash
+   git clone https://github.com/rygn-dev/olive-call-transcription.git
+   cd olive-call-transcription
+   ```
+
+3. (Optional) Install XcodeGen:
+   ```bash
+   brew install xcodegen
+   ```
+
+4. Open `Olive.xcodeproj` in Xcode
+
+5. Configure visual assets as described in [Installation](#installation)
+
+### Building
+
+Open the project in Xcode and build with ⌘B or:
+
+```bash
+xcodebuild build -scheme Olive -configuration Debug
+```
+
+### Project Structure
+
+```
+Olive/
+├── CallTranscription/           # Main application code
+│   ├── Audio/                   # Audio capture components
+│   ├── Transcription/           # Speech recognition
+│   ├── Settings/                # User preferences
+│   ├── Views/                   # SwiftUI interface
+│   ├── Storage/                 # File writing
+│   ├── Permissions/             # Permission handlers
+│   └── PostProcessing/          # Post-recording automation
+├── CallTranscriptionTests/      # Test suite
+├── architecture.md              # Detailed architecture documentation
+├── project.yml                  # XcodeGen configuration
+└── README.md                    # This file
+```
+
+## Architecture
+
+Olive follows a modular architecture with clear separation of concerns:
+
+- **Audio Layer**: Non-invasive audio capture using Core Audio taps and AVAudioEngine
+- **Transcription Layer**: Apple Speech framework integration
+- **Storage Layer**: File output and naming
+- **UI Layer**: SwiftUI menu bar interface
+- **Settings Layer**: UserDefaults persistence
+
+For detailed architecture information, see [architecture.md](architecture.md).
+
+## Testing
+
+Olive uses **Test-Driven Development (TDD)** with comprehensive test coverage.
+
+### Running Tests
+
+```bash
+xcodebuild test -scheme Olive -destination 'platform=macOS'
+```
+
+Or in Xcode: Product → Test (⌘U)
+
+### Test Categories
+
+- **Unit Tests**: Individual component testing
+- **Integration Tests**: Cross-component workflows
+- **End-to-End Tests**: Full recording scenarios
+- **Performance Tests**: Long recording sessions
+
+### TDD Workflow
+
+All features follow strict TDD methodology:
+
+1. Write failing tests first
+2. Implement minimal code to pass tests
+3. Refactor while keeping tests green
+
+See [CLAUDE.md](CLAUDE.md) for TDD requirements.
+
+## Contributing
+
+Contributions are welcome! Please follow these guidelines:
+
+### Development Workflow
+
+1. Fork the repository
+2. Create a feature branch from `dev`
+3. **Write tests first** (TDD is mandatory)
+4. Implement the feature
+5. Ensure all tests pass
+6. Submit a pull request to `dev` branch
+
+### Code Standards
+
+- **Swift 6** strict concurrency
+- **SwiftUI** for all UI components
+- **Test coverage required** for all new code
+- **TDD methodology mandatory** - tests before implementation
+- Follow existing code patterns and structure
+
+### Pull Request Requirements
+
+- All tests must pass
+- New features must have test coverage
+- Commit messages follow conventional format
+- Code must pass all linting checks
+- PR description includes rationale and test plan
+
+## Troubleshooting
+
+### Common Errors
+
+#### "Olive needs permission to access the microphone"
+
+**Solution**: Grant microphone permission in System Settings → Privacy & Security → Microphone
+
+#### "Speech recognition unavailable"
+
+**Solution**: Grant speech recognition permission in System Settings → Privacy & Security → Speech Recognition
+
+#### "Recording failed to start"
+
+**Possible causes**:
+- Microphone already in use by another application
+- Permissions not granted
+- Audio device disconnected
+
+**Solution**: Close other apps using the microphone, check permissions, verify audio devices
+
+### Permission Issues
+
+If permission dialogs don't appear:
+
+1. Reset permissions:
+   ```bash
+   tccutil reset Microphone
+   tccutil reset SpeechRecognition
+   ```
+
+2. Restart Olive and try recording again
+
+### Audio Capture Issues
+
+#### No audio recorded from system
+
+**Solution**: Enable "System Audio" in Settings and ensure the target app (Zoom, etc.) is playing audio
+
+#### Microphone not recording
+
+**Solution**:
+- Check microphone is selected in System Settings → Sound → Input
+- Verify microphone permission granted to Olive
+- Test microphone in another app first
+
+#### Transcript file is empty
+
+**Possible causes**:
+- No audio detected during recording
+- Speech recognition didn't detect any speech
+- Output folder permission denied
+
+**Solution**: Verify audio sources enabled, check output folder write permissions, try longer recording
+
+### Build Errors
+
+#### "Missing privacy descriptions in Info.plist"
+
+**Solution**: The project validation should catch this. Ensure Info.plist contains:
+- `NSMicrophoneUsageDescription`
+- `NSSpeechRecognitionUsageDescription`
+
+#### "Visual assets not found"
+
+**Solution**: Follow the manual asset configuration steps in [Installation](#installation)
+
+### Getting Help
+
+- Check existing [GitHub Issues](https://github.com/rygn-dev/olive-call-transcription/issues)
+- Review [architecture.md](architecture.md) for technical details
+- Open a new issue with:
+  - macOS version
+  - Xcode version
+  - Full error message
+  - Steps to reproduce
+
+## License
+
+See LICENSE file for details.
+
+## Acknowledgments
+
+Built using Apple's native Speech framework and Core Audio APIs.


### PR DESCRIPTION
## Summary

Implements comprehensive documentation for Olive following TDD methodology.

- Added 18 documentation tests covering README completeness (TDD: written first, committed before implementation)
- Expanded README from 18 lines to 327 lines with complete user and developer documentation
- All documentation tests pass (18/18)

## Implementation Details

### Test Coverage (DocumentationTests.swift)

Tests verify README includes:
- Project description and requirements
- Installation and build instructions  
- Usage guide and settings documentation
- Permission requirements and grant procedures
- Development setup and architecture reference
- Testing approach (TDD) and contribution guidelines
- Troubleshooting for common errors, permissions, and audio issues

### Documentation Additions (README.md)

**User Documentation:**
- Features: dual audio recording, real-time transcription, silence detection
- Requirements: macOS 26.0+, Xcode 16+
- Installation: from source with visual asset configuration
- Usage: starting/stopping recordings, transcript file locations
- Settings: output folder, audio sources, post-recording scripts
- Permissions: microphone and speech recognition with grant instructions

**Developer Documentation:**
- Project setup and building instructions
- Project structure overview
- Architecture reference to architecture.md
- Testing: TDD workflow, test categories, running tests
- Contributing: development workflow, code standards, PR requirements

**Troubleshooting:**
- Common errors (permissions, recording failures)
- Permission issues (reset procedures)
- Audio capture problems (system audio, microphone)
- Build errors (Info.plist, visual assets)

## TDD Workflow Followed

1. ✅ Tests written first (commit a2121c1)
2. ✅ Tests failed initially (9/18 failures as expected)
3. ✅ Implementation added to pass tests (commit 0d6fad6)
4. ✅ All tests now pass (18/18)

## Test Plan

```bash
xcodebuild test -scheme Olive -destination 'platform=macOS' -only-testing:CallTranscriptionTests/DocumentationTests
```

Result: All 18 documentation tests pass

Closes #24