### PR TITLE
feat: Add loading state for shortcuts dropdown in Settings (Issue #81)

### DIFF
--- a/CallTranscription/Settings/SettingsView.swift
+++ b/CallTranscription/Settings/SettingsView.swift
@@ -116,6 +116,7 @@ struct SettingsView: View {
                     HStack {
                         ProgressView()
                             .scaleEffect(0.7)
+                            .accessibilityLabel("Loading shortcuts")
                         Text("Loading shortcuts...")
                             .foregroundColor(.secondary)
                     }
@@ -192,6 +193,7 @@ struct SettingsView: View {
     // MARK: - Shortcuts Integration
 
     private func loadAvailableShortcuts() {
+        guard !isLoadingShortcuts else { return } // Prevent concurrent loads
         Task {
             isLoadingShortcuts = true
             let executor = ShortcutExecutor()

--- a/CallTranscription/Settings/SettingsView.swift
+++ b/CallTranscription/Settings/SettingsView.swift
@@ -13,6 +13,7 @@ struct SettingsView: View {
     @AppStorage("saveOriginalAudio") private var saveOriginalAudio: Bool = SettingsManager.defaultSaveOriginalAudio
 
     @State private var availableShortcuts: [String] = []
+    @State private var isLoadingShortcuts: Bool = false
 
     var body: some View {
         Form {
@@ -111,17 +112,32 @@ struct SettingsView: View {
 
             // Show shortcut picker when shortcut is selected
             if PostRecordingActionType(rawValue: postRecordingActionTypeRaw) == .shortcut {
-                Picker("Shortcut:", selection: $shortcutIdentifier) {
-                    Text("Select a shortcut...").tag("")
-                    ForEach(availableShortcuts, id: \.self) { shortcut in
-                        Text(shortcut).tag(shortcut)
+                if isLoadingShortcuts {
+                    HStack {
+                        ProgressView()
+                            .scaleEffect(0.7)
+                        Text("Loading shortcuts...")
+                            .foregroundColor(.secondary)
+                    }
+                } else {
+                    Picker("Shortcut:", selection: $shortcutIdentifier) {
+                        Text("Select a shortcut...").tag("")
+                        ForEach(availableShortcuts, id: \.self) { shortcut in
+                            Text(shortcut).tag(shortcut)
+                        }
+                    }
+                    .pickerStyle(.menu)
+
+                    if availableShortcuts.isEmpty {
+                        Text("No shortcuts found. Create shortcuts in the Shortcuts app first.")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+                    } else {
+                        Text("The shortcut receives the transcript file path as input")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
                     }
                 }
-                .pickerStyle(.menu)
-
-                Text("The shortcut receives the transcript file path as input")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
             }
         }
         .onAppear {
@@ -177,8 +193,10 @@ struct SettingsView: View {
 
     private func loadAvailableShortcuts() {
         Task {
+            isLoadingShortcuts = true
             let executor = ShortcutExecutor()
             availableShortcuts = await executor.listAvailableShortcuts()
+            isLoadingShortcuts = false
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added loading indicator while shortcuts are being loaded
- Added empty state message when no shortcuts are available
- Improved user experience with clear visual feedback

## Implementation Details

**UI States:**
1. **Loading State** - Shows ProgressView with "Loading shortcuts..." message
2. **Empty State** - Shows orange warning message when no shortcuts found
3. **Normal State** - Shows shortcuts picker with help text

**Changes:**
- Added `@State isLoadingShortcuts` boolean to track loading state
- Updated `loadAvailableShortcuts()` to set loading flags before/after async call
- Conditional UI rendering based on loading state:
  - While loading: Shows progress indicator
  - After loading (empty): Shows helpful message to create shortcuts
  - After loading (populated): Shows picker with shortcuts

**User Experience Improvements:**
- No more silent loading period with empty dropdown
- Clear feedback when shortcuts command is running
- Helpful guidance when user has no shortcuts configured
- Maintains all existing functionality

## Test Plan
- [x] Build succeeds without errors or warnings
- [x] UI shows loading indicator (verified in preview/manual testing)
- [x] Empty state message displays when no shortcuts available
- [x] Picker works normally when shortcuts are loaded
- [x] Existing SettingsView tests still pass

Closes #81