### PR TITLE
feat: localize SettingsView Part 1 sections (Issue #46, Phase 2A PR2)

### DIFF
--- a/CallTranscription/Resources/Localizable.xcstrings
+++ b/CallTranscription/Resources/Localizable.xcstrings
@@ -378,6 +378,318 @@
           }
         }
       }
+    },
+    "settings.output.header": {
+      "comment": "Output section header",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output"
+          }
+        }
+      }
+    },
+    "settings.output.folder.label": {
+      "comment": "Output folder text field label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output Folder"
+          }
+        }
+      }
+    },
+    "settings.output.folder.browseButton": {
+      "comment": "Browse button for output folder",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse..."
+          }
+        }
+      }
+    },
+    "settings.output.saveOriginalAudio.label": {
+      "comment": "Save original audio toggle label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Original Audio File"
+          }
+        }
+      }
+    },
+    "settings.output.helpText": {
+      "comment": "Output section help text",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcripts will be saved to this folder. When enabled, original audio recordings will also be saved in M4A format."
+          }
+        }
+      }
+    },
+    "settings.output.folder.accessibility.label": {
+      "comment": "Output folder accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output Folder"
+          }
+        }
+      }
+    },
+    "settings.output.folder.accessibility.hint": {
+      "comment": "Output folder accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path where transcripts will be saved"
+          }
+        }
+      }
+    },
+    "settings.output.folder.browse.accessibility.label": {
+      "comment": "Browse button accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse for Output Folder"
+          }
+        }
+      }
+    },
+    "settings.output.folder.browse.accessibility.hint": {
+      "comment": "Browse button accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens a dialog to select where transcripts will be saved"
+          }
+        }
+      }
+    },
+    "settings.output.saveOriginalAudio.accessibility.label": {
+      "comment": "Save original audio accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Original Audio File"
+          }
+        }
+      }
+    },
+    "settings.output.saveOriginalAudio.accessibility.hint": {
+      "comment": "Save original audio accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When enabled, saves original audio recordings in M4A format alongside transcripts"
+          }
+        }
+      }
+    },
+    "settings.output.folder.dialog.prompt": {
+      "comment": "Output folder dialog prompt",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Output Folder"
+          }
+        }
+      }
+    },
+    "settings.output.folder.dialog.message": {
+      "comment": "Output folder dialog message",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose where transcripts will be saved"
+          }
+        }
+      }
+    },
+    "settings.audioSources.header": {
+      "comment": "Audio sources section header",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Sources"
+          }
+        }
+      }
+    },
+    "settings.audioSources.captureSystemAudio.label": {
+      "comment": "Capture system audio toggle label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture System Audio (Zoom, Teams, etc.)"
+          }
+        }
+      }
+    },
+    "settings.audioSources.captureMicrophone.label": {
+      "comment": "Capture microphone toggle label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture Microphone Input"
+          }
+        }
+      }
+    },
+    "settings.audioSources.helpText": {
+      "comment": "Audio sources help text",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "At least one audio source must be enabled"
+          }
+        }
+      }
+    },
+    "settings.audioSources.captureSystemAudio.accessibility.label": {
+      "comment": "Capture system audio accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture System Audio"
+          }
+        }
+      }
+    },
+    "settings.audioSources.captureSystemAudio.accessibility.hint": {
+      "comment": "Capture system audio accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Records audio from applications like Zoom, Teams, and other system sounds"
+          }
+        }
+      }
+    },
+    "settings.audioSources.captureMicrophone.accessibility.label": {
+      "comment": "Capture microphone accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture Microphone Input"
+          }
+        }
+      }
+    },
+    "settings.audioSources.captureMicrophone.accessibility.hint": {
+      "comment": "Capture microphone accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Records audio from your microphone. At least one audio source must be enabled"
+          }
+        }
+      }
+    },
+    "settings.silenceDetection.header": {
+      "comment": "Silence detection section header",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Silence Detection"
+          }
+        }
+      }
+    },
+    "settings.silenceDetection.autoPause.label": {
+      "comment": "Auto-pause picker label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-pause after silence:"
+          }
+        }
+      }
+    },
+    "settings.silenceDetection.helpText": {
+      "comment": "Silence detection help text",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically pause recording after continuous silence. Recording will auto-resume when audio is detected."
+          }
+        }
+      }
+    },
+    "settings.silenceDetection.autoPause.accessibility.label": {
+      "comment": "Auto-pause accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-pause after silence"
+          }
+        }
+      }
+    },
+    "settings.silenceDetection.autoPause.accessibility.hint": {
+      "comment": "Auto-pause accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically pause recording after continuous silence. Recording will auto-resume when audio is detected"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/CallTranscription/Settings/SettingsView.swift
+++ b/CallTranscription/Settings/SettingsView.swift
@@ -34,31 +34,31 @@ struct SettingsView: View {
     private var outputSection: some View {
         Section {
             HStack {
-                TextField("Output Folder", text: $outputFolder)
+                TextField(LocalizedStringKey("settings.output.folder.label"), text: $outputFolder)
                     .textFieldStyle(.roundedBorder)
                     .accessibilityIdentifier("outputFolderTextField")
-                    .accessibilityLabel("Output Folder")
-                    .accessibilityHint("Path where transcripts will be saved")
+                    .accessibilityLabel(LocalizedStringKey("settings.output.folder.accessibility.label"))
+                    .accessibilityHint(LocalizedStringKey("settings.output.folder.accessibility.hint"))
 
-                Button("Browse...") {
+                Button(LocalizedStringKey("settings.output.folder.browseButton")) {
                     selectOutputFolder()
                 }
                 .accessibilityIdentifier("outputFolderBrowseButton")
-                .accessibilityLabel("Browse for Output Folder")
-                .accessibilityHint("Opens a dialog to select where transcripts will be saved")
+                .accessibilityLabel(LocalizedStringKey("settings.output.folder.browse.accessibility.label"))
+                .accessibilityHint(LocalizedStringKey("settings.output.folder.browse.accessibility.hint"))
             }
 
-            Toggle("Save Original Audio File", isOn: $saveOriginalAudio)
+            Toggle(LocalizedStringKey("settings.output.saveOriginalAudio.label"), isOn: $saveOriginalAudio)
                 .accessibilityIdentifier("saveOriginalAudioToggle")
-                .accessibilityLabel("Save Original Audio File")
-                .accessibilityHint("When enabled, saves original audio recordings in M4A format alongside transcripts")
+                .accessibilityLabel(LocalizedStringKey("settings.output.saveOriginalAudio.accessibility.label"))
+                .accessibilityHint(LocalizedStringKey("settings.output.saveOriginalAudio.accessibility.hint"))
 
-            Text("Transcripts will be saved to this folder. When enabled, original audio recordings will also be saved in M4A format.")
+            Text(LocalizedStringKey("settings.output.helpText"))
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .accessibilityHidden(true)
         } header: {
-            Text("Output")
+            Text(LocalizedStringKey("settings.output.header"))
                 .accessibilityAddTraits(.isHeader)
         }
     }
@@ -67,22 +67,22 @@ struct SettingsView: View {
 
     private var audioSourcesSection: some View {
         Section {
-            Toggle("Capture System Audio (Zoom, Teams, etc.)", isOn: $captureSystemAudio)
+            Toggle(LocalizedStringKey("settings.audioSources.captureSystemAudio.label"), isOn: $captureSystemAudio)
                 .accessibilityIdentifier("captureSystemAudioToggle")
-                .accessibilityLabel("Capture System Audio")
-                .accessibilityHint("Records audio from applications like Zoom, Teams, and other system sounds")
+                .accessibilityLabel(LocalizedStringKey("settings.audioSources.captureSystemAudio.accessibility.label"))
+                .accessibilityHint(LocalizedStringKey("settings.audioSources.captureSystemAudio.accessibility.hint"))
 
-            Toggle("Capture Microphone Input", isOn: $captureMicrophone)
+            Toggle(LocalizedStringKey("settings.audioSources.captureMicrophone.label"), isOn: $captureMicrophone)
                 .accessibilityIdentifier("captureMicrophoneToggle")
-                .accessibilityLabel("Capture Microphone Input")
-                .accessibilityHint("Records audio from your microphone. At least one audio source must be enabled")
+                .accessibilityLabel(LocalizedStringKey("settings.audioSources.captureMicrophone.accessibility.label"))
+                .accessibilityHint(LocalizedStringKey("settings.audioSources.captureMicrophone.accessibility.hint"))
 
-            Text("At least one audio source must be enabled")
+            Text(LocalizedStringKey("settings.audioSources.helpText"))
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .accessibilityHidden(true)
         } header: {
-            Text("Audio Sources")
+            Text(LocalizedStringKey("settings.audioSources.header"))
                 .accessibilityAddTraits(.isHeader)
         }
     }
@@ -91,7 +91,7 @@ struct SettingsView: View {
 
     private var silenceDetectionSection: some View {
         Section {
-            Picker("Auto-pause after silence:", selection: Binding(
+            Picker(LocalizedStringKey("settings.silenceDetection.autoPause.label"), selection: Binding(
                 get: { SilencePauseThreshold(rawValue: silencePauseThresholdRaw) ?? .never },
                 set: { silencePauseThresholdRaw = $0.rawValue }
             )) {
@@ -101,15 +101,15 @@ struct SettingsView: View {
             }
             .pickerStyle(.menu)
             .accessibilityIdentifier("silencePauseThresholdPicker")
-            .accessibilityLabel("Auto-pause after silence")
-            .accessibilityHint("Automatically pause recording after continuous silence. Recording will auto-resume when audio is detected")
+            .accessibilityLabel(LocalizedStringKey("settings.silenceDetection.autoPause.accessibility.label"))
+            .accessibilityHint(LocalizedStringKey("settings.silenceDetection.autoPause.accessibility.hint"))
 
-            Text("Automatically pause recording after continuous silence. Recording will auto-resume when audio is detected.")
+            Text(LocalizedStringKey("settings.silenceDetection.helpText"))
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .accessibilityHidden(true)
         } header: {
-            Text("Silence Detection")
+            Text(LocalizedStringKey("settings.silenceDetection.header"))
                 .accessibilityAddTraits(.isHeader)
         }
     }
@@ -208,8 +208,8 @@ struct SettingsView: View {
         panel.canChooseDirectories = true
         panel.canCreateDirectories = true
         panel.allowsMultipleSelection = false
-        panel.prompt = "Select Output Folder"
-        panel.message = "Choose where transcripts will be saved"
+        panel.prompt = NSLocalizedString("settings.output.folder.dialog.prompt", comment: "Output folder dialog prompt")
+        panel.message = NSLocalizedString("settings.output.folder.dialog.message", comment: "Output folder dialog message")
 
         // Set initial directory if current path exists
         let expandedPath = NSString(string: outputFolder).expandingTildeInPath

--- a/CallTranscriptionTests/Localization/SettingsViewPart1LocalizationTests.swift
+++ b/CallTranscriptionTests/Localization/SettingsViewPart1LocalizationTests.swift
@@ -1,0 +1,231 @@
+import XCTest
+@testable import CallTranscription
+
+/// Tests for SettingsView Part 1 localization (Output, Audio Sources, Silence Detection sections).
+///
+/// These tests verify that all user-facing strings in the first three sections of
+/// SettingsView are properly externalized to the String Catalog.
+final class SettingsViewPart1LocalizationTests: XCTestCase {
+
+    // MARK: - Output Section Tests
+
+    func testOutputSectionHeaderIsLocalized() {
+        let key = "settings.output.header"
+        let localizedValue = NSLocalizedString(key, comment: "Output section header")
+
+        XCTAssertNotEqual(localizedValue, key, "Output section header should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Output section header should not be empty")
+    }
+
+    func testOutputFolderLabelIsLocalized() {
+        let key = "settings.output.folder.label"
+        let localizedValue = NSLocalizedString(key, comment: "Output folder label")
+
+        XCTAssertNotEqual(localizedValue, key, "Output folder label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Output folder label should not be empty")
+    }
+
+    func testOutputFolderBrowseButtonIsLocalized() {
+        let key = "settings.output.folder.browseButton"
+        let localizedValue = NSLocalizedString(key, comment: "Browse button for output folder")
+
+        XCTAssertNotEqual(localizedValue, key, "Browse button label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Browse button label should not be empty")
+    }
+
+    func testSaveOriginalAudioToggleLabelIsLocalized() {
+        let key = "settings.output.saveOriginalAudio.label"
+        let localizedValue = NSLocalizedString(key, comment: "Save original audio toggle label")
+
+        XCTAssertNotEqual(localizedValue, key, "Save original audio toggle label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Save original audio toggle label should not be empty")
+    }
+
+    func testOutputHelpTextIsLocalized() {
+        let key = "settings.output.helpText"
+        let localizedValue = NSLocalizedString(key, comment: "Output section help text")
+
+        XCTAssertNotEqual(localizedValue, key, "Output help text should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Output help text should not be empty")
+    }
+
+    // MARK: - Output Section Accessibility Tests
+
+    func testOutputFolderAccessibilityLabelIsLocalized() {
+        let key = "settings.output.folder.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Output folder accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Output folder accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Output folder accessibility label should not be empty")
+    }
+
+    func testOutputFolderAccessibilityHintIsLocalized() {
+        let key = "settings.output.folder.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Output folder accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Output folder accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Output folder accessibility hint should not be empty")
+    }
+
+    func testOutputFolderBrowseAccessibilityLabelIsLocalized() {
+        let key = "settings.output.folder.browse.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Browse button accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Browse button accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Browse button accessibility label should not be empty")
+    }
+
+    func testOutputFolderBrowseAccessibilityHintIsLocalized() {
+        let key = "settings.output.folder.browse.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Browse button accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Browse button accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Browse button accessibility hint should not be empty")
+    }
+
+    func testSaveOriginalAudioAccessibilityLabelIsLocalized() {
+        let key = "settings.output.saveOriginalAudio.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Save original audio accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Save original audio accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Save original audio accessibility label should not be empty")
+    }
+
+    func testSaveOriginalAudioAccessibilityHintIsLocalized() {
+        let key = "settings.output.saveOriginalAudio.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Save original audio accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Save original audio accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Save original audio accessibility hint should not be empty")
+    }
+
+    // MARK: - Output Dialog Tests
+
+    func testOutputFolderDialogPromptIsLocalized() {
+        let key = "settings.output.folder.dialog.prompt"
+        let localizedValue = NSLocalizedString(key, comment: "Output folder dialog prompt")
+
+        XCTAssertNotEqual(localizedValue, key, "Output folder dialog prompt should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Output folder dialog prompt should not be empty")
+    }
+
+    func testOutputFolderDialogMessageIsLocalized() {
+        let key = "settings.output.folder.dialog.message"
+        let localizedValue = NSLocalizedString(key, comment: "Output folder dialog message")
+
+        XCTAssertNotEqual(localizedValue, key, "Output folder dialog message should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Output folder dialog message should not be empty")
+    }
+
+    // MARK: - Audio Sources Section Tests
+
+    func testAudioSourcesSectionHeaderIsLocalized() {
+        let key = "settings.audioSources.header"
+        let localizedValue = NSLocalizedString(key, comment: "Audio sources section header")
+
+        XCTAssertNotEqual(localizedValue, key, "Audio sources section header should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Audio sources section header should not be empty")
+    }
+
+    func testCaptureSystemAudioLabelIsLocalized() {
+        let key = "settings.audioSources.captureSystemAudio.label"
+        let localizedValue = NSLocalizedString(key, comment: "Capture system audio toggle label")
+
+        XCTAssertNotEqual(localizedValue, key, "Capture system audio label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Capture system audio label should not be empty")
+    }
+
+    func testCaptureMicrophoneLabelIsLocalized() {
+        let key = "settings.audioSources.captureMicrophone.label"
+        let localizedValue = NSLocalizedString(key, comment: "Capture microphone toggle label")
+
+        XCTAssertNotEqual(localizedValue, key, "Capture microphone label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Capture microphone label should not be empty")
+    }
+
+    func testAudioSourcesHelpTextIsLocalized() {
+        let key = "settings.audioSources.helpText"
+        let localizedValue = NSLocalizedString(key, comment: "Audio sources help text")
+
+        XCTAssertNotEqual(localizedValue, key, "Audio sources help text should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Audio sources help text should not be empty")
+    }
+
+    // MARK: - Audio Sources Accessibility Tests
+
+    func testCaptureSystemAudioAccessibilityLabelIsLocalized() {
+        let key = "settings.audioSources.captureSystemAudio.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Capture system audio accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Capture system audio accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Capture system audio accessibility label should not be empty")
+    }
+
+    func testCaptureSystemAudioAccessibilityHintIsLocalized() {
+        let key = "settings.audioSources.captureSystemAudio.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Capture system audio accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Capture system audio accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Capture system audio accessibility hint should not be empty")
+    }
+
+    func testCaptureMicrophoneAccessibilityLabelIsLocalized() {
+        let key = "settings.audioSources.captureMicrophone.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Capture microphone accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Capture microphone accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Capture microphone accessibility label should not be empty")
+    }
+
+    func testCaptureMicrophoneAccessibilityHintIsLocalized() {
+        let key = "settings.audioSources.captureMicrophone.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Capture microphone accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Capture microphone accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Capture microphone accessibility hint should not be empty")
+    }
+
+    // MARK: - Silence Detection Section Tests
+
+    func testSilenceDetectionSectionHeaderIsLocalized() {
+        let key = "settings.silenceDetection.header"
+        let localizedValue = NSLocalizedString(key, comment: "Silence detection section header")
+
+        XCTAssertNotEqual(localizedValue, key, "Silence detection section header should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Silence detection section header should not be empty")
+    }
+
+    func testAutoPauseLabelIsLocalized() {
+        let key = "settings.silenceDetection.autoPause.label"
+        let localizedValue = NSLocalizedString(key, comment: "Auto-pause picker label")
+
+        XCTAssertNotEqual(localizedValue, key, "Auto-pause label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Auto-pause label should not be empty")
+    }
+
+    func testSilenceDetectionHelpTextIsLocalized() {
+        let key = "settings.silenceDetection.helpText"
+        let localizedValue = NSLocalizedString(key, comment: "Silence detection help text")
+
+        XCTAssertNotEqual(localizedValue, key, "Silence detection help text should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Silence detection help text should not be empty")
+    }
+
+    // MARK: - Silence Detection Accessibility Tests
+
+    func testAutoPauseAccessibilityLabelIsLocalized() {
+        let key = "settings.silenceDetection.autoPause.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Auto-pause accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Auto-pause accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Auto-pause accessibility label should not be empty")
+    }
+
+    func testAutoPauseAccessibilityHintIsLocalized() {
+        let key = "settings.silenceDetection.autoPause.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Auto-pause accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Auto-pause accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Auto-pause accessibility hint should not be empty")
+    }
+}

--- a/Olive.xcodeproj/project.pbxproj
+++ b/Olive.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		E677AD9CE31EA46B860EB01C /* OutputFolderManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4DE81C3FBB277DD83F66AC /* OutputFolderManagerTests.swift */; };
 		EC636BDA3F980B84EB5B1CA6 /* TranscriptionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38D6FF52EC1C1B8DED6F095 /* TranscriptionManagerTests.swift */; };
 		ECAC234A1784BE93CA802A10 /* MicrophoneCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661EF16D5EE1366035BC2141 /* MicrophoneCaptureTests.swift */; };
+		F0868F0B3B58B1C8E9B81F93 /* SettingsViewPart1LocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C553264E2BEC77EBFDA63D /* SettingsViewPart1LocalizationTests.swift */; };
 		F74E8FFC67136B49D5647BED /* SystemAudioCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F8DE56AE6A1D906B04577D /* SystemAudioCaptureTests.swift */; };
 		FF46D0CEF84D6571340AC619 /* ConsentDialogViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC68A1C8D09F5F1981FA49A4 /* ConsentDialogViewTests.swift */; };
 		FF709386F695A885ADE80224 /* RecordingSessionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E28C8E9612924BB5C64308 /* RecordingSessionCoordinator.swift */; };
@@ -131,6 +132,7 @@
 		7E7A54A678DA5B048E710A0E /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		837EB55A7B5FA3FCC3F48B0C /* ConfigureSettingsIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureSettingsIntentTests.swift; sourceTree = "<group>"; };
 		83E15EB281B79A6B4C0CC140 /* AudioMixerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMixerTests.swift; sourceTree = "<group>"; };
+		86C553264E2BEC77EBFDA63D /* SettingsViewPart1LocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewPart1LocalizationTests.swift; sourceTree = "<group>"; };
 		88F77224D3D8A90FADD99091 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		8CFC3A44160366392EB433DF /* AppShortcutsProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShortcutsProviderTests.swift; sourceTree = "<group>"; };
 		95AC1A98A7166B70D569FCAE /* AppleScriptIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptIntegrationTests.swift; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 			children = (
 				6737A13ABCCCBFBB9AA11127 /* LocalizationInfrastructureTests.swift */,
 				3A5C3850689572C9A2C55CE4 /* MenuBarViewLocalizationTests.swift */,
+				86C553264E2BEC77EBFDA63D /* SettingsViewPart1LocalizationTests.swift */,
 			);
 			path = Localization;
 			sourceTree = "<group>";
@@ -641,6 +644,7 @@
 				8540D429DC2F0F7244CFED02 /* SettingsManagerTests.swift in Sources */,
 				5D314F676298F5F207DA2409 /* SettingsViewAccessibilityTests.swift in Sources */,
 				C3C9EB6DEB88192A2315379B /* SettingsViewCacheTests.swift in Sources */,
+				F0868F0B3B58B1C8E9B81F93 /* SettingsViewPart1LocalizationTests.swift in Sources */,
 				B389554621A06C69E8D96312 /* SettingsViewTests.swift in Sources */,
 				4DD997AC21F137568A88FD79 /* ShellScriptExecutorTests.swift in Sources */,
 				864FCECF141EE8467DD83EC6 /* ShortcutExecutorTests.swift in Sources */,


### PR DESCRIPTION
## Summary

Externalizes all hardcoded user-facing strings in SettingsView Part 1 (Output, Audio Sources, and Silence Detection sections) to the String Catalog for internationalization support.

- Replaced 26 hardcoded strings with localized equivalents
- Added comprehensive test coverage for all localized strings
- Maintains full VoiceOver accessibility support with localized labels and hints
- All strings currently in English; translations for other languages in Phase 3

## Changes

### String Catalog (`Localizable.xcstrings`)
Added 26 SettingsView Part 1 localization keys with English values:

**Output Section (11 keys):**
- TextField label: "Output Folder"
- Browse button: "Browse..."
- Toggle: "Save Original Audio File"
- Help text describing folder and audio file saving
- Section header: "Output"
- Accessibility labels and hints for all controls
- Dialog prompt and message for folder selection

**Audio Sources Section (8 keys):**
- 2 Toggle labels: "Capture System Audio (Zoom, Teams, etc.)" and "Capture Microphone Input"
- Help text: "At least one audio source must be enabled"
- Section header: "Audio Sources"
- Accessibility labels and hints for both toggles

**Silence Detection Section (5 keys):**
- Picker label: "Auto-pause after silence:"
- Help text describing auto-pause behavior
- Section header: "Silence Detection"
- Accessibility label and hint for picker

**Dialog Strings (2 keys):**
- Output folder dialog prompt and message

### SettingsView.swift
- Replaced all hardcoded strings in Output, Audio Sources, and Silence Detection sections
- Used `LocalizedStringKey` for SwiftUI components (Text, TextField, Button, Toggle)
- Used `NSLocalizedString` for dialog prompts (NS OpenPanel requires String type)
- Maintained all existing functionality and accessibility features
- Post-Recording section left unchanged for separate PR

### Test Coverage
- **Created** `SettingsViewPart1LocalizationTests.swift`
  - 26 comprehensive tests covering all localized strings
  - Verifies each key exists in String Catalog
  - Ensures no string returns the key itself
- All 26 tests passing ✅

## Technical Decisions

**Scope Split:**
- Part 1 (this PR): Output, Audio Sources, Silence Detection sections (26 strings)
- Part 2 (next PR): Post-Recording section with conditional controls (~22 strings)
- This split keeps PRs manageable and respects functional boundaries

**String Hierarchy:**
- `settings.output.*` - Output section strings
- `settings.audioSources.*` - Audio Sources section strings
- `settings.silenceDetection.*` - Silence Detection section strings
- Clear subcategories: `.label`, `.helpText`, `.accessibility.label`, `.accessibility.hint`, `.dialog.prompt`

## Test Plan

- [x] All 26 SettingsView Part 1 localization tests pass
- [x] Project builds successfully
- [x] No compilation errors or warnings
- [x] All existing SettingsView functionality preserved
- [x] Accessibility labels and hints still work
- [x] Output folder dialog displays with localized strings

## TDD Evidence

This PR follows strict test-driven development:

1. **First commit** (`b99f270`): "test: add SettingsView Part 1 localization tests (TDD)"
   - Wrote all 26 tests before implementation
   - Tests initially failed

2. **Second commit** (`01ea731`): "feat: localize SettingsView Part 1..."
   - Added strings to catalog
   - Updated SettingsView sections
   - All 26 tests now passing

## Related Issues

Part of #46 (Phase 2A: UI Localization - PR 2 of 4)

## Next Steps

After this PR merges:
- **PR 3**: Localize SettingsView Part 2 (Post-Recording section)
- **PR 4**: Localize ConsentDialogView and SilencePauseThreshold
- **Phase 3**: Add translations for es, fr, de, ja, zh-Hans