### PR TITLE
feat: localize SettingsView Part 2 - Post-Recording section (Issue #46, Phase 2A PR3)

### DIFF
--- a/CallTranscription/Resources/Localizable.xcstrings
+++ b/CallTranscription/Resources/Localizable.xcstrings
@@ -690,6 +690,294 @@
           }
         }
       }
+    },
+    "settings.postRecording.header": {
+      "comment": "Post-recording section header",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Post-Recording Action"
+          }
+        }
+      }
+    },
+    "settings.postRecording.afterRecording.label": {
+      "comment": "After recording picker label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After recording:"
+          }
+        }
+      }
+    },
+    "settings.postRecording.action.doNothing": {
+      "comment": "Do nothing radio option",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do nothing"
+          }
+        }
+      }
+    },
+    "settings.postRecording.action.runScript": {
+      "comment": "Run script radio option",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run a script"
+          }
+        }
+      }
+    },
+    "settings.postRecording.action.runShortcut": {
+      "comment": "Run shortcut radio option",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run a shortcut"
+          }
+        }
+      }
+    },
+    "settings.postRecording.script.path.label": {
+      "comment": "Script path text field label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell Script Path"
+          }
+        }
+      }
+    },
+    "settings.postRecording.script.browseButton": {
+      "comment": "Browse button for script",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse..."
+          }
+        }
+      }
+    },
+    "settings.postRecording.script.helpText": {
+      "comment": "Script help text",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Script receives transcript path as $1"
+          }
+        }
+      }
+    },
+    "settings.postRecording.shortcut.loading": {
+      "comment": "Loading shortcuts text",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading shortcuts..."
+          }
+        }
+      }
+    },
+    "settings.postRecording.shortcut.picker.label": {
+      "comment": "Shortcut picker label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut:"
+          }
+        }
+      }
+    },
+    "settings.postRecording.shortcut.placeholder": {
+      "comment": "Shortcut picker placeholder",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a shortcut..."
+          }
+        }
+      }
+    },
+    "settings.postRecording.shortcut.noShortcuts": {
+      "comment": "No shortcuts found message",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No shortcuts found. Create shortcuts in the Shortcuts app first."
+          }
+        }
+      }
+    },
+    "settings.postRecording.shortcut.helpText": {
+      "comment": "Shortcut help text",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The shortcut receives the transcript file path as input"
+          }
+        }
+      }
+    },
+    "settings.postRecording.afterRecording.accessibility.label": {
+      "comment": "After recording accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After recording"
+          }
+        }
+      }
+    },
+    "settings.postRecording.afterRecording.accessibility.hint": {
+      "comment": "After recording accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose what happens when recording stops: do nothing, run a script, or run a shortcut"
+          }
+        }
+      }
+    },
+    "settings.postRecording.script.path.accessibility.label": {
+      "comment": "Script path accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell Script Path"
+          }
+        }
+      }
+    },
+    "settings.postRecording.script.path.accessibility.hint": {
+      "comment": "Script path accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path to shell script that will receive the transcript file path as its first argument"
+          }
+        }
+      }
+    },
+    "settings.postRecording.script.browse.accessibility.label": {
+      "comment": "Script browse accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse for Script"
+          }
+        }
+      }
+    },
+    "settings.postRecording.script.browse.accessibility.hint": {
+      "comment": "Script browse accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens a dialog to select a shell script to run after recording"
+          }
+        }
+      }
+    },
+    "settings.postRecording.shortcut.picker.accessibility.label": {
+      "comment": "Shortcut picker accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut"
+          }
+        }
+      }
+    },
+    "settings.postRecording.shortcut.picker.accessibility.hint": {
+      "comment": "Shortcut picker accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a shortcut that will receive the transcript file path as input"
+          }
+        }
+      }
+    },
+    "settings.postRecording.shortcut.loading.accessibility.label": {
+      "comment": "Loading shortcuts accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading shortcuts"
+          }
+        }
+      }
+    },
+    "settings.postRecording.script.dialog.prompt": {
+      "comment": "Script dialog prompt",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Script"
+          }
+        }
+      }
+    },
+    "settings.postRecording.script.dialog.message": {
+      "comment": "Script dialog message",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a shell script to run after recording completes"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/CallTranscription/Settings/SettingsView.swift
+++ b/CallTranscription/Settings/SettingsView.swift
@@ -118,37 +118,37 @@ struct SettingsView: View {
 
     private var postRecordingSection: some View {
         Section {
-            Picker("After recording:", selection: Binding(
+            Picker(LocalizedStringKey("settings.postRecording.afterRecording.label"), selection: Binding(
                 get: { PostRecordingActionType(rawValue: postRecordingActionTypeRaw) ?? .doNothing },
                 set: { postRecordingActionTypeRaw = $0.rawValue }
             )) {
-                Text("Do nothing").tag(PostRecordingActionType.doNothing)
-                Text("Run a script").tag(PostRecordingActionType.script)
-                Text("Run a shortcut").tag(PostRecordingActionType.shortcut)
+                Text(LocalizedStringKey("settings.postRecording.action.doNothing")).tag(PostRecordingActionType.doNothing)
+                Text(LocalizedStringKey("settings.postRecording.action.runScript")).tag(PostRecordingActionType.script)
+                Text(LocalizedStringKey("settings.postRecording.action.runShortcut")).tag(PostRecordingActionType.shortcut)
             }
             .pickerStyle(.radioGroup)
             .accessibilityIdentifier("postRecordingActionPicker")
-            .accessibilityLabel("After recording")
-            .accessibilityHint("Choose what happens when recording stops: do nothing, run a script, or run a shortcut")
+            .accessibilityLabel(LocalizedStringKey("settings.postRecording.afterRecording.accessibility.label"))
+            .accessibilityHint(LocalizedStringKey("settings.postRecording.afterRecording.accessibility.hint"))
 
             // Show script picker when script is selected
             if PostRecordingActionType(rawValue: postRecordingActionTypeRaw) == .script {
                 HStack {
-                    TextField("Shell Script Path", text: $postRecordingScript)
+                    TextField(LocalizedStringKey("settings.postRecording.script.path.label"), text: $postRecordingScript)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityIdentifier("postRecordingScriptTextField")
-                        .accessibilityLabel("Shell Script Path")
-                        .accessibilityHint("Path to shell script that will receive the transcript file path as its first argument")
+                        .accessibilityLabel(LocalizedStringKey("settings.postRecording.script.path.accessibility.label"))
+                        .accessibilityHint(LocalizedStringKey("settings.postRecording.script.path.accessibility.hint"))
 
-                    Button("Browse...") {
+                    Button(LocalizedStringKey("settings.postRecording.script.browseButton")) {
                         selectPostRecordingScript()
                     }
                     .accessibilityIdentifier("postRecordingScriptBrowseButton")
-                    .accessibilityLabel("Browse for Script")
-                    .accessibilityHint("Opens a dialog to select a shell script to run after recording")
+                    .accessibilityLabel(LocalizedStringKey("settings.postRecording.script.browse.accessibility.label"))
+                    .accessibilityHint(LocalizedStringKey("settings.postRecording.script.browse.accessibility.hint"))
                 }
 
-                Text("Script receives transcript path as $1")
+                Text(LocalizedStringKey("settings.postRecording.script.helpText"))
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .accessibilityHidden(true)
@@ -160,31 +160,31 @@ struct SettingsView: View {
                     HStack {
                         ProgressView()
                             .scaleEffect(0.7)
-                            .accessibilityLabel("Loading shortcuts")
+                            .accessibilityLabel(LocalizedStringKey("settings.postRecording.shortcut.loading.accessibility.label"))
                             .accessibilityIdentifier("shortcutsLoadingIndicator")
-                        Text("Loading shortcuts...")
+                        Text(LocalizedStringKey("settings.postRecording.shortcut.loading"))
                             .foregroundColor(.secondary)
                             .accessibilityHidden(true)
                     }
                 } else {
-                    Picker("Shortcut:", selection: $shortcutIdentifier) {
-                        Text("Select a shortcut...").tag("")
+                    Picker(LocalizedStringKey("settings.postRecording.shortcut.picker.label"), selection: $shortcutIdentifier) {
+                        Text(LocalizedStringKey("settings.postRecording.shortcut.placeholder")).tag("")
                         ForEach(availableShortcuts, id: \.self) { shortcut in
                             Text(shortcut).tag(shortcut)
                         }
                     }
                     .pickerStyle(.menu)
                     .accessibilityIdentifier("shortcutPicker")
-                    .accessibilityLabel("Shortcut")
-                    .accessibilityHint("Choose a shortcut that will receive the transcript file path as input")
+                    .accessibilityLabel(LocalizedStringKey("settings.postRecording.shortcut.picker.accessibility.label"))
+                    .accessibilityHint(LocalizedStringKey("settings.postRecording.shortcut.picker.accessibility.hint"))
 
                     if availableShortcuts.isEmpty {
-                        Text("No shortcuts found. Create shortcuts in the Shortcuts app first.")
+                        Text(LocalizedStringKey("settings.postRecording.shortcut.noShortcuts"))
                             .font(.caption)
                             .foregroundColor(.orange)
                             .accessibilityHidden(true)
                     } else {
-                        Text("The shortcut receives the transcript file path as input")
+                        Text(LocalizedStringKey("settings.postRecording.shortcut.helpText"))
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .accessibilityHidden(true)
@@ -192,7 +192,7 @@ struct SettingsView: View {
                 }
             }
         } header: {
-            Text("Post-Recording Action")
+            Text(LocalizedStringKey("settings.postRecording.header"))
                 .accessibilityAddTraits(.isHeader)
         }
         .onAppear {
@@ -228,8 +228,8 @@ struct SettingsView: View {
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
         panel.allowedContentTypes = [.shellScript, .executable, .unixExecutable]
-        panel.prompt = "Select Script"
-        panel.message = "Choose a shell script to run after recording completes"
+        panel.prompt = NSLocalizedString("settings.postRecording.script.dialog.prompt", comment: "Script dialog prompt")
+        panel.message = NSLocalizedString("settings.postRecording.script.dialog.message", comment: "Script dialog message")
 
         // Set initial directory if current path exists
         if !postRecordingScript.isEmpty {

--- a/CallTranscriptionTests/Localization/SettingsViewPart2LocalizationTests.swift
+++ b/CallTranscriptionTests/Localization/SettingsViewPart2LocalizationTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+@testable import CallTranscription
+
+/// Tests for SettingsView Part 2 localization (Post-Recording section).
+///
+/// These tests verify that all user-facing strings in the Post-Recording section
+/// are properly externalized to the String Catalog.
+final class SettingsViewPart2LocalizationTests: XCTestCase {
+
+    // MARK: - Post-Recording Section Tests
+
+    func testPostRecordingSectionHeaderIsLocalized() {
+        let key = "settings.postRecording.header"
+        let localizedValue = NSLocalizedString(key, comment: "Post-recording section header")
+
+        XCTAssertNotEqual(localizedValue, key, "Post-recording section header should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Post-recording section header should not be empty")
+    }
+
+    func testAfterRecordingLabelIsLocalized() {
+        let key = "settings.postRecording.afterRecording.label"
+        let localizedValue = NSLocalizedString(key, comment: "After recording picker label")
+
+        XCTAssertNotEqual(localizedValue, key, "After recording label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "After recording label should not be empty")
+    }
+
+    // MARK: - Action Type Radio Options Tests
+
+    func testDoNothingOptionIsLocalized() {
+        let key = "settings.postRecording.action.doNothing"
+        let localizedValue = NSLocalizedString(key, comment: "Do nothing radio option")
+
+        XCTAssertNotEqual(localizedValue, key, "Do nothing option should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Do nothing option should not be empty")
+    }
+
+    func testRunScriptOptionIsLocalized() {
+        let key = "settings.postRecording.action.runScript"
+        let localizedValue = NSLocalizedString(key, comment: "Run script radio option")
+
+        XCTAssertNotEqual(localizedValue, key, "Run script option should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Run script option should not be empty")
+    }
+
+    func testRunShortcutOptionIsLocalized() {
+        let key = "settings.postRecording.action.runShortcut"
+        let localizedValue = NSLocalizedString(key, comment: "Run shortcut radio option")
+
+        XCTAssertNotEqual(localizedValue, key, "Run shortcut option should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Run shortcut option should not be empty")
+    }
+
+    // MARK: - Script Section Tests
+
+    func testScriptPathLabelIsLocalized() {
+        let key = "settings.postRecording.script.path.label"
+        let localizedValue = NSLocalizedString(key, comment: "Script path text field label")
+
+        XCTAssertNotEqual(localizedValue, key, "Script path label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script path label should not be empty")
+    }
+
+    func testScriptBrowseButtonIsLocalized() {
+        let key = "settings.postRecording.script.browseButton"
+        let localizedValue = NSLocalizedString(key, comment: "Browse button for script")
+
+        XCTAssertNotEqual(localizedValue, key, "Script browse button should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script browse button should not be empty")
+    }
+
+    func testScriptHelpTextIsLocalized() {
+        let key = "settings.postRecording.script.helpText"
+        let localizedValue = NSLocalizedString(key, comment: "Script help text")
+
+        XCTAssertNotEqual(localizedValue, key, "Script help text should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script help text should not be empty")
+    }
+
+    // MARK: - Shortcut Section Tests
+
+    func testLoadingShortcutsTextIsLocalized() {
+        let key = "settings.postRecording.shortcut.loading"
+        let localizedValue = NSLocalizedString(key, comment: "Loading shortcuts text")
+
+        XCTAssertNotEqual(localizedValue, key, "Loading shortcuts text should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Loading shortcuts text should not be empty")
+    }
+
+    func testShortcutPickerLabelIsLocalized() {
+        let key = "settings.postRecording.shortcut.picker.label"
+        let localizedValue = NSLocalizedString(key, comment: "Shortcut picker label")
+
+        XCTAssertNotEqual(localizedValue, key, "Shortcut picker label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Shortcut picker label should not be empty")
+    }
+
+    func testShortcutPlaceholderIsLocalized() {
+        let key = "settings.postRecording.shortcut.placeholder"
+        let localizedValue = NSLocalizedString(key, comment: "Shortcut picker placeholder")
+
+        XCTAssertNotEqual(localizedValue, key, "Shortcut placeholder should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Shortcut placeholder should not be empty")
+    }
+
+    func testNoShortcutsMessageIsLocalized() {
+        let key = "settings.postRecording.shortcut.noShortcuts"
+        let localizedValue = NSLocalizedString(key, comment: "No shortcuts found message")
+
+        XCTAssertNotEqual(localizedValue, key, "No shortcuts message should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "No shortcuts message should not be empty")
+    }
+
+    func testShortcutHelpTextIsLocalized() {
+        let key = "settings.postRecording.shortcut.helpText"
+        let localizedValue = NSLocalizedString(key, comment: "Shortcut help text")
+
+        XCTAssertNotEqual(localizedValue, key, "Shortcut help text should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Shortcut help text should not be empty")
+    }
+
+    // MARK: - Post-Recording Accessibility Tests
+
+    func testAfterRecordingAccessibilityLabelIsLocalized() {
+        let key = "settings.postRecording.afterRecording.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "After recording accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "After recording accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "After recording accessibility label should not be empty")
+    }
+
+    func testAfterRecordingAccessibilityHintIsLocalized() {
+        let key = "settings.postRecording.afterRecording.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "After recording accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "After recording accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "After recording accessibility hint should not be empty")
+    }
+
+    func testScriptPathAccessibilityLabelIsLocalized() {
+        let key = "settings.postRecording.script.path.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Script path accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Script path accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script path accessibility label should not be empty")
+    }
+
+    func testScriptPathAccessibilityHintIsLocalized() {
+        let key = "settings.postRecording.script.path.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Script path accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Script path accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script path accessibility hint should not be empty")
+    }
+
+    func testScriptBrowseAccessibilityLabelIsLocalized() {
+        let key = "settings.postRecording.script.browse.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Script browse accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Script browse accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script browse accessibility label should not be empty")
+    }
+
+    func testScriptBrowseAccessibilityHintIsLocalized() {
+        let key = "settings.postRecording.script.browse.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Script browse accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Script browse accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script browse accessibility hint should not be empty")
+    }
+
+    func testShortcutPickerAccessibilityLabelIsLocalized() {
+        let key = "settings.postRecording.shortcut.picker.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Shortcut picker accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Shortcut picker accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Shortcut picker accessibility label should not be empty")
+    }
+
+    func testShortcutPickerAccessibilityHintIsLocalized() {
+        let key = "settings.postRecording.shortcut.picker.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Shortcut picker accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Shortcut picker accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Shortcut picker accessibility hint should not be empty")
+    }
+
+    func testLoadingShortcutsAccessibilityLabelIsLocalized() {
+        let key = "settings.postRecording.shortcut.loading.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Loading shortcuts accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Loading shortcuts accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Loading shortcuts accessibility label should not be empty")
+    }
+
+    // MARK: - Script Dialog Tests
+
+    func testScriptDialogPromptIsLocalized() {
+        let key = "settings.postRecording.script.dialog.prompt"
+        let localizedValue = NSLocalizedString(key, comment: "Script dialog prompt")
+
+        XCTAssertNotEqual(localizedValue, key, "Script dialog prompt should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script dialog prompt should not be empty")
+    }
+
+    func testScriptDialogMessageIsLocalized() {
+        let key = "settings.postRecording.script.dialog.message"
+        let localizedValue = NSLocalizedString(key, comment: "Script dialog message")
+
+        XCTAssertNotEqual(localizedValue, key, "Script dialog message should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script dialog message should not be empty")
+    }
+}

--- a/Olive.xcodeproj/project.pbxproj
+++ b/Olive.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0EBD5316A0F3E5E9493AFACE /* SilencePauseThreshold.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4859E4D9A79148CCAB4AC5 /* SilencePauseThreshold.swift */; };
 		0F886F808C24AD1FAA99478B /* StopRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB21276D4BACDB7EB8606C4 /* StopRecordingIntent.swift */; };
 		12CFA8919C1C890A1ED1A70C /* AppStateContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D6A0D2DE53B9F2DE0D9903 /* AppStateContainer.swift */; };
+		1577D551178C6B5EEE6C6837 /* SettingsViewPart2LocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BCA284D9E5C1C6222A8467 /* SettingsViewPart2LocalizationTests.swift */; };
 		162F637936AD7628883EBD65 /* SettingsViewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656AAD017BD8575B48738BE6 /* SettingsViewCache.swift */; };
 		1874D46A24881DD6BE7AAAD0 /* ShellScriptExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA8803714DCC07DE2BE7968 /* ShellScriptExecutor.swift */; };
 		1BB70970282EF3C43F08326D /* ScriptableApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F6EAB05A984DD0715379AA /* ScriptableApplication.swift */; };
@@ -160,6 +161,7 @@
 		C7902940F09F84F685C1EE40 /* MenuBarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewTests.swift; sourceTree = "<group>"; };
 		CC68A1C8D09F5F1981FA49A4 /* ConsentDialogViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentDialogViewTests.swift; sourceTree = "<group>"; };
 		D38D6FF52EC1C1B8DED6F095 /* TranscriptionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionManagerTests.swift; sourceTree = "<group>"; };
+		E0BCA284D9E5C1C6222A8467 /* SettingsViewPart2LocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewPart2LocalizationTests.swift; sourceTree = "<group>"; };
 		E1F72653C0B9DF850283C9D0 /* ConfigureSettingsIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureSettingsIntent.swift; sourceTree = "<group>"; };
 		E5D003BED620B269E29D8CDA /* MicrophoneCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneCapture.swift; sourceTree = "<group>"; };
 		E8CD4216B9C3A5370BCC0C34 /* SettingsViewCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewCacheTests.swift; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 				6737A13ABCCCBFBB9AA11127 /* LocalizationInfrastructureTests.swift */,
 				3A5C3850689572C9A2C55CE4 /* MenuBarViewLocalizationTests.swift */,
 				86C553264E2BEC77EBFDA63D /* SettingsViewPart1LocalizationTests.swift */,
+				E0BCA284D9E5C1C6222A8467 /* SettingsViewPart2LocalizationTests.swift */,
 			);
 			path = Localization;
 			sourceTree = "<group>";
@@ -645,6 +648,7 @@
 				5D314F676298F5F207DA2409 /* SettingsViewAccessibilityTests.swift in Sources */,
 				C3C9EB6DEB88192A2315379B /* SettingsViewCacheTests.swift in Sources */,
 				F0868F0B3B58B1C8E9B81F93 /* SettingsViewPart1LocalizationTests.swift in Sources */,
+				1577D551178C6B5EEE6C6837 /* SettingsViewPart2LocalizationTests.swift in Sources */,
 				B389554621A06C69E8D96312 /* SettingsViewTests.swift in Sources */,
 				4DD997AC21F137568A88FD79 /* ShellScriptExecutorTests.swift in Sources */,
 				864FCECF141EE8467DD83EC6 /* ShortcutExecutorTests.swift in Sources */,


### PR DESCRIPTION
## Summary

Externalizes all hardcoded user-facing strings in SettingsView Post-Recording section to the String Catalog for internationalization support.

- Replaced 24 hardcoded strings with localized equivalents
- Added comprehensive test coverage for all localized strings
- Maintains full VoiceOver accessibility support with localized labels and hints
- All strings currently in English; translations for other languages in Phase 3

## Changes

### String Catalog (`Localizable.xcstrings`)
Added 24 SettingsView Part 2 localization keys with English values:

**Post-Recording Section (24 keys):**
- Section header: "Post-Recording Action"
- Picker label: "After recording:"
- Radio options (3): "Do nothing", "Run a script", "Run a shortcut"
- Script controls (3): TextField label, Browse button, help text
- Shortcut controls (5): Loading text, Picker label, placeholder, no shortcuts message, help text
- Accessibility labels and hints for all controls (9)
- Script selection dialog prompt and message (2)

### SettingsView.swift
- Replaced all hardcoded strings in Post-Recording section
- Used `LocalizedStringKey` for SwiftUI components (Text, TextField, Button, Picker)
- Used `NSLocalizedString` for dialog prompts (NSOpenPanel requires String type)
- Maintained all existing functionality and accessibility features
- All conditional controls properly localized

### Test Coverage
- **Created** `SettingsViewPart2LocalizationTests.swift`
  - 24 comprehensive tests (originally 25, but one combines into existing key)
  - Verifies each key exists in String Catalog
  - Ensures no string returns the key itself
- All 24 tests passing ✅

## Technical Decisions

**Complete SettingsView Localization:**
- Part 1 (PR #98): Output, Audio Sources, Silence Detection sections (26 strings)
- Part 2 (this PR): Post-Recording section (24 strings)
- **Total**: 50 SettingsView strings fully localized ✅

**String Hierarchy:**
- `settings.postRecording.*` - Post-Recording section strings
- Clear subcategories: `.action.*`, `.script.*`, `.shortcut.*`, `.accessibility.*`, `.dialog.*`

**Conditional Controls:**
- Script controls only visible when "Run a script" selected
- Shortcut controls only visible when "Run a shortcut" selected
- All conditional strings properly localized

## Test Plan

- [x] All 24 SettingsView Part 2 localization tests pass
- [x] Project builds successfully
- [x] No compilation errors or warnings
- [x] All existing SettingsView functionality preserved
- [x] Accessibility labels and hints still work
- [x] Conditional controls display correctly with localized strings
- [x] Script selection dialog displays with localized prompts

## TDD Evidence

This PR follows strict test-driven development:

1. **First commit** (`3c03919`): "test: add SettingsView Part 2 localization tests (TDD)"
   - Wrote all 25 tests before implementation
   - Tests initially failed

2. **Second commit** (`ba97e38`): "feat: localize SettingsView Part 2..."
   - Added strings to catalog
   - Updated SettingsView Post-Recording section
   - All 24 tests now passing

## Related Issues

Part of #46 (Phase 2A: UI Localization - PR 3 of 4)

## Next Steps

After this PR merges:
- **PR 4**: Localize ConsentDialogView and SilencePauseThreshold (final Phase 2A PR)
- **Phase 2B**: Localize business logic (4 PRs)
- **Phase 3**: Add translations for es, fr, de, ja, zh-Hans