### PR TITLE
feat: localize ConsentDialog and SilencePauseThreshold (Phase 2A PR4)

### DIFF
--- a/CallTranscription/Resources/Localizable.xcstrings
+++ b/CallTranscription/Resources/Localizable.xcstrings
@@ -978,6 +978,282 @@
           }
         }
       }
+    },
+    "consentDialog.title": {
+      "comment": "Consent dialog title",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Important: Recording Consent Requirements"
+          }
+        }
+      }
+    },
+    "consentDialog.intro": {
+      "comment": "Consent dialog intro text",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Before using this app to record conversations, please understand:"
+          }
+        }
+      }
+    },
+    "consentDialog.bullet1": {
+      "comment": "First bullet point",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording laws vary significantly by jurisdiction"
+          }
+        }
+      }
+    },
+    "consentDialog.bullet2": {
+      "comment": "Second bullet point",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some regions require only one party's consent (one-party consent states)"
+          }
+        }
+      }
+    },
+    "consentDialog.bullet3": {
+      "comment": "Third bullet point",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Other regions require all parties to consent before recording (two-party or all-party consent)"
+          }
+        }
+      }
+    },
+    "consentDialog.bullet4": {
+      "comment": "Fourth bullet point",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "International laws differ dramatically across countries"
+          }
+        }
+      }
+    },
+    "consentDialog.responsibility": {
+      "comment": "User responsibility text",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You are solely responsible for ensuring compliance with all applicable laws in your jurisdiction before recording any conversation."
+          }
+        }
+      }
+    },
+    "consentDialog.warning": {
+      "comment": "Legal warning text",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failure to obtain proper consent may result in civil or criminal liability."
+          }
+        }
+      }
+    },
+    "consentDialog.checkbox.label": {
+      "comment": "Do not remind checkbox label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do not remind me again"
+          }
+        }
+      }
+    },
+    "consentDialog.button.quit": {
+      "comment": "Quit button label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
+          }
+        }
+      }
+    },
+    "consentDialog.button.understand": {
+      "comment": "I Understand button label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I Understand"
+          }
+        }
+      }
+    },
+    "consentDialog.title.accessibility.label": {
+      "comment": "Title accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Important: Recording Consent Requirements"
+          }
+        }
+      }
+    },
+    "consentDialog.body.accessibility.label": {
+      "comment": "Body accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legal requirements"
+          }
+        }
+      }
+    },
+    "consentDialog.checkbox.accessibility.label": {
+      "comment": "Checkbox accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do not remind me again"
+          }
+        }
+      }
+    },
+    "consentDialog.checkbox.accessibility.hint": {
+      "comment": "Checkbox accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When checked, this consent dialog will not be shown again on future launches"
+          }
+        }
+      }
+    },
+    "consentDialog.quit.accessibility.label": {
+      "comment": "Quit accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
+          }
+        }
+      }
+    },
+    "consentDialog.quit.accessibility.hint": {
+      "comment": "Quit accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quits the application without accepting consent requirements. Keyboard shortcut: Escape"
+          }
+        }
+      }
+    },
+    "consentDialog.understand.accessibility.label": {
+      "comment": "I Understand accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I Understand"
+          }
+        }
+      }
+    },
+    "consentDialog.understand.accessibility.hint": {
+      "comment": "I Understand accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acknowledges consent requirements and dismisses this dialog. Keyboard shortcut: Return"
+          }
+        }
+      }
+    },
+    "silenceThreshold.twoMinutes": {
+      "comment": "2 minutes threshold",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 minutes"
+          }
+        }
+      }
+    },
+    "silenceThreshold.fiveMinutes": {
+      "comment": "5 minutes threshold",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 minutes"
+          }
+        }
+      }
+    },
+    "silenceThreshold.tenMinutes": {
+      "comment": "10 minutes threshold",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 minutes"
+          }
+        }
+      }
+    },
+    "silenceThreshold.never": {
+      "comment": "Never threshold",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Never"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/CallTranscription/Settings/SilencePauseThreshold.swift
+++ b/CallTranscription/Settings/SilencePauseThreshold.swift
@@ -35,13 +35,13 @@ public enum SilencePauseThreshold: String, Codable, CaseIterable, Sendable {
     public var displayName: String {
         switch self {
         case .twoMinutes:
-            return "2 minutes"
+            return NSLocalizedString("silenceThreshold.twoMinutes", comment: "2 minutes threshold")
         case .fiveMinutes:
-            return "5 minutes"
+            return NSLocalizedString("silenceThreshold.fiveMinutes", comment: "5 minutes threshold")
         case .tenMinutes:
-            return "10 minutes"
+            return NSLocalizedString("silenceThreshold.tenMinutes", comment: "10 minutes threshold")
         case .never:
-            return "Never"
+            return NSLocalizedString("silenceThreshold.never", comment: "Never threshold")
         }
     }
 }

--- a/CallTranscription/Views/ConsentDialogView.swift
+++ b/CallTranscription/Views/ConsentDialogView.swift
@@ -12,70 +12,70 @@ struct ConsentDialogView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             // Title
-            Text("Important: Recording Consent Requirements")
+            Text(LocalizedStringKey("consentDialog.title"))
                 .font(.title2)
                 .fontWeight(.bold)
                 .accessibilityIdentifier("consentDialogTitle")
                 .accessibilityAddTraits(.isHeader)
-                .accessibilityLabel("Important: Recording Consent Requirements")
+                .accessibilityLabel(LocalizedStringKey("consentDialog.title.accessibility.label"))
 
             // Body text explaining legal obligations
             VStack(alignment: .leading, spacing: 12) {
-                Text("Before using this app to record conversations, please understand:")
+                Text(LocalizedStringKey("consentDialog.intro"))
                     .font(.body)
 
                 VStack(alignment: .leading, spacing: 8) {
-                    bulletPoint("Recording laws vary significantly by jurisdiction")
-                    bulletPoint("Some regions require only one party's consent (one-party consent states)")
-                    bulletPoint("Other regions require all parties to consent before recording (two-party or all-party consent)")
-                    bulletPoint("International laws differ dramatically across countries")
+                    bulletPoint(NSLocalizedString("consentDialog.bullet1", comment: "First bullet point"))
+                    bulletPoint(NSLocalizedString("consentDialog.bullet2", comment: "Second bullet point"))
+                    bulletPoint(NSLocalizedString("consentDialog.bullet3", comment: "Third bullet point"))
+                    bulletPoint(NSLocalizedString("consentDialog.bullet4", comment: "Fourth bullet point"))
                 }
                 .accessibilityElement(children: .combine)
 
-                Text("You are solely responsible for ensuring compliance with all applicable laws in your jurisdiction before recording any conversation.")
+                Text(LocalizedStringKey("consentDialog.responsibility"))
                     .font(.body)
                     .fontWeight(.semibold)
                     .padding(.top, 8)
 
-                Text("Failure to obtain proper consent may result in civil or criminal liability.")
+                Text(LocalizedStringKey("consentDialog.warning"))
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.top, 4)
             }
             .accessibilityIdentifier("consentDialogBody")
-            .accessibilityLabel("Legal requirements")
+            .accessibilityLabel(LocalizedStringKey("consentDialog.body.accessibility.label"))
 
             Divider()
 
             // Checkbox for "Do not remind me again"
             Toggle(isOn: $doNotRemindAgain) {
-                Text("Do not remind me again")
+                Text(LocalizedStringKey("consentDialog.checkbox.label"))
                     .font(.body)
             }
             .toggleStyle(.checkbox)
             .accessibilityIdentifier("doNotRemindCheckbox")
-            .accessibilityLabel("Do not remind me again")
-            .accessibilityHint("When checked, this consent dialog will not be shown again on future launches")
+            .accessibilityLabel(LocalizedStringKey("consentDialog.checkbox.accessibility.label"))
+            .accessibilityHint(LocalizedStringKey("consentDialog.checkbox.accessibility.hint"))
 
             // Buttons
             HStack {
                 Spacer()
 
-                Button("Quit") {
+                Button(LocalizedStringKey("consentDialog.button.quit")) {
                     NSApplication.shared.terminate(nil)
                 }
                 .keyboardShortcut(.cancelAction)
                 .accessibilityIdentifier("quitButton")
-                .accessibilityLabel("Quit")
-                .accessibilityHint("Quits the application without accepting consent requirements. Keyboard shortcut: Escape")
+                .accessibilityLabel(LocalizedStringKey("consentDialog.quit.accessibility.label"))
+                .accessibilityHint(LocalizedStringKey("consentDialog.quit.accessibility.hint"))
 
-                Button("I Understand") {
+                Button(LocalizedStringKey("consentDialog.button.understand")) {
                     appState.dismissConsentDialog(rememberChoice: doNotRemindAgain)
                 }
                 .keyboardShortcut(.defaultAction)
                 .accessibilityIdentifier("iUnderstandButton")
-                .accessibilityLabel("I Understand")
-                .accessibilityHint("Acknowledges consent requirements and dismisses this dialog. Keyboard shortcut: Return")
+                .accessibilityLabel(LocalizedStringKey("consentDialog.understand.accessibility.label"))
+                .accessibilityHint(LocalizedStringKey("consentDialog.understand.accessibility.hint"))
             }
             .padding(.top, 8)
         }

--- a/CallTranscriptionTests/Localization/ConsentDialogAndSilenceLocalizationTests.swift
+++ b/CallTranscriptionTests/Localization/ConsentDialogAndSilenceLocalizationTests.swift
@@ -1,0 +1,199 @@
+import XCTest
+@testable import CallTranscription
+
+/// Tests for ConsentDialogView and SilencePauseThreshold localization.
+///
+/// These tests verify that all user-facing strings in ConsentDialogView and
+/// SilencePauseThreshold are properly externalized to the String Catalog.
+final class ConsentDialogAndSilenceLocalizationTests: XCTestCase {
+
+    // MARK: - ConsentDialogView Tests
+
+    func testConsentDialogTitleIsLocalized() {
+        let key = "consentDialog.title"
+        let localizedValue = NSLocalizedString(key, comment: "Consent dialog title")
+
+        XCTAssertNotEqual(localizedValue, key, "Consent dialog title should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Consent dialog title should not be empty")
+    }
+
+    func testConsentDialogIntroTextIsLocalized() {
+        let key = "consentDialog.intro"
+        let localizedValue = NSLocalizedString(key, comment: "Consent dialog intro text")
+
+        XCTAssertNotEqual(localizedValue, key, "Consent dialog intro should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Consent dialog intro should not be empty")
+    }
+
+    func testConsentDialogBullet1IsLocalized() {
+        let key = "consentDialog.bullet1"
+        let localizedValue = NSLocalizedString(key, comment: "First bullet point")
+
+        XCTAssertNotEqual(localizedValue, key, "Bullet point 1 should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Bullet point 1 should not be empty")
+    }
+
+    func testConsentDialogBullet2IsLocalized() {
+        let key = "consentDialog.bullet2"
+        let localizedValue = NSLocalizedString(key, comment: "Second bullet point")
+
+        XCTAssertNotEqual(localizedValue, key, "Bullet point 2 should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Bullet point 2 should not be empty")
+    }
+
+    func testConsentDialogBullet3IsLocalized() {
+        let key = "consentDialog.bullet3"
+        let localizedValue = NSLocalizedString(key, comment: "Third bullet point")
+
+        XCTAssertNotEqual(localizedValue, key, "Bullet point 3 should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Bullet point 3 should not be empty")
+    }
+
+    func testConsentDialogBullet4IsLocalized() {
+        let key = "consentDialog.bullet4"
+        let localizedValue = NSLocalizedString(key, comment: "Fourth bullet point")
+
+        XCTAssertNotEqual(localizedValue, key, "Bullet point 4 should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Bullet point 4 should not be empty")
+    }
+
+    func testConsentDialogResponsibilityTextIsLocalized() {
+        let key = "consentDialog.responsibility"
+        let localizedValue = NSLocalizedString(key, comment: "User responsibility text")
+
+        XCTAssertNotEqual(localizedValue, key, "Responsibility text should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Responsibility text should not be empty")
+    }
+
+    func testConsentDialogWarningTextIsLocalized() {
+        let key = "consentDialog.warning"
+        let localizedValue = NSLocalizedString(key, comment: "Legal warning text")
+
+        XCTAssertNotEqual(localizedValue, key, "Warning text should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Warning text should not be empty")
+    }
+
+    func testConsentDialogCheckboxLabelIsLocalized() {
+        let key = "consentDialog.checkbox.label"
+        let localizedValue = NSLocalizedString(key, comment: "Do not remind checkbox label")
+
+        XCTAssertNotEqual(localizedValue, key, "Checkbox label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Checkbox label should not be empty")
+    }
+
+    func testConsentDialogQuitButtonIsLocalized() {
+        let key = "consentDialog.button.quit"
+        let localizedValue = NSLocalizedString(key, comment: "Quit button label")
+
+        XCTAssertNotEqual(localizedValue, key, "Quit button should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Quit button should not be empty")
+    }
+
+    func testConsentDialogUnderstandButtonIsLocalized() {
+        let key = "consentDialog.button.understand"
+        let localizedValue = NSLocalizedString(key, comment: "I Understand button label")
+
+        XCTAssertNotEqual(localizedValue, key, "I Understand button should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "I Understand button should not be empty")
+    }
+
+    // MARK: - ConsentDialogView Accessibility Tests
+
+    func testConsentDialogTitleAccessibilityLabelIsLocalized() {
+        let key = "consentDialog.title.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Title accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Title accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Title accessibility label should not be empty")
+    }
+
+    func testConsentDialogBodyAccessibilityLabelIsLocalized() {
+        let key = "consentDialog.body.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Body accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Body accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Body accessibility label should not be empty")
+    }
+
+    func testConsentDialogCheckboxAccessibilityLabelIsLocalized() {
+        let key = "consentDialog.checkbox.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Checkbox accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Checkbox accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Checkbox accessibility label should not be empty")
+    }
+
+    func testConsentDialogCheckboxAccessibilityHintIsLocalized() {
+        let key = "consentDialog.checkbox.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Checkbox accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Checkbox accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Checkbox accessibility hint should not be empty")
+    }
+
+    func testConsentDialogQuitAccessibilityLabelIsLocalized() {
+        let key = "consentDialog.quit.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "Quit accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "Quit accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Quit accessibility label should not be empty")
+    }
+
+    func testConsentDialogQuitAccessibilityHintIsLocalized() {
+        let key = "consentDialog.quit.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "Quit accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "Quit accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Quit accessibility hint should not be empty")
+    }
+
+    func testConsentDialogUnderstandAccessibilityLabelIsLocalized() {
+        let key = "consentDialog.understand.accessibility.label"
+        let localizedValue = NSLocalizedString(key, comment: "I Understand accessibility label")
+
+        XCTAssertNotEqual(localizedValue, key, "I Understand accessibility label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "I Understand accessibility label should not be empty")
+    }
+
+    func testConsentDialogUnderstandAccessibilityHintIsLocalized() {
+        let key = "consentDialog.understand.accessibility.hint"
+        let localizedValue = NSLocalizedString(key, comment: "I Understand accessibility hint")
+
+        XCTAssertNotEqual(localizedValue, key, "I Understand accessibility hint should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "I Understand accessibility hint should not be empty")
+    }
+
+    // MARK: - SilencePauseThreshold Tests
+
+    func testSilenceThresholdTwoMinutesIsLocalized() {
+        let key = "silenceThreshold.twoMinutes"
+        let localizedValue = NSLocalizedString(key, comment: "2 minutes threshold")
+
+        XCTAssertNotEqual(localizedValue, key, "2 minutes threshold should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "2 minutes threshold should not be empty")
+    }
+
+    func testSilenceThresholdFiveMinutesIsLocalized() {
+        let key = "silenceThreshold.fiveMinutes"
+        let localizedValue = NSLocalizedString(key, comment: "5 minutes threshold")
+
+        XCTAssertNotEqual(localizedValue, key, "5 minutes threshold should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "5 minutes threshold should not be empty")
+    }
+
+    func testSilenceThresholdTenMinutesIsLocalized() {
+        let key = "silenceThreshold.tenMinutes"
+        let localizedValue = NSLocalizedString(key, comment: "10 minutes threshold")
+
+        XCTAssertNotEqual(localizedValue, key, "10 minutes threshold should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "10 minutes threshold should not be empty")
+    }
+
+    func testSilenceThresholdNeverIsLocalized() {
+        let key = "silenceThreshold.never"
+        let localizedValue = NSLocalizedString(key, comment: "Never threshold")
+
+        XCTAssertNotEqual(localizedValue, key, "Never threshold should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Never threshold should not be empty")
+    }
+}


### PR DESCRIPTION
## Summary

Completes Phase 2A (UI localization) by externalizing all hardcoded strings in ConsentDialogView and SilencePauseThreshold to the String Catalog.

**Scope:**
- ConsentDialogView: Title, body text, 4 bullet points, checkbox, buttons (Quit/Understand)
- SilencePauseThreshold: Display names for all 4 threshold options (2min/5min/10min/Never)
- All VoiceOver accessibility labels and hints

**TDD Methodology:**
- ✅ Tests written first (committed separately in earlier commit)
- ✅ All 23 tests passing
- ✅ Build succeeds with no errors

**Changes:**
- Added 23 localization keys to String Catalog
- Updated ConsentDialogView to use LocalizedStringKey/NSLocalizedString
- Updated SilencePauseThreshold.displayName to use NSLocalizedString
- Maintained full VoiceOver accessibility support

**Testing:**
- 23/23 tests passing in ConsentDialogAndSilenceLocalizationTests
- Verified build succeeds
- No regressions

## Impact

- Completes Phase 2A: All UI strings now externalized to String Catalog
- Ready for Phase 2B: Business logic localization
- Total UI keys: 102 (MenuBarView: 28, Settings Part 1: 26, Settings Part 2: 24, ConsentDialog/Silence: 23, Infrastructure: 1)

## Related Issues

- Part of #46 (Comprehensive localization/internationalization support)
- Builds on PRs #96, #97, #98, #99