### PR TITLE
feat: localize Intent messages and statuses (Phase 2B PR2)

### DIFF
--- a/CallTranscription/Intents/GetRecordingStatusIntent.swift
+++ b/CallTranscription/Intents/GetRecordingStatusIntent.swift
@@ -21,12 +21,12 @@ struct GetRecordingStatusIntent: AppIntent {
         let statusMessage: String
         if appState.isRecording {
             if appState.isPaused {
-                statusMessage = "Recording paused at \(appState.elapsedTime)"
+                statusMessage = String(format: NSLocalizedString("intent.status.recordingPaused", comment: "Recording paused status message"), appState.elapsedTime)
             } else {
-                statusMessage = "Recording in progress: \(appState.elapsedTime)"
+                statusMessage = String(format: NSLocalizedString("intent.status.recordingInProgress", comment: "Recording in progress status message"), appState.elapsedTime)
             }
         } else {
-            statusMessage = "Not recording"
+            statusMessage = NSLocalizedString("intent.status.notRecording", comment: "Not recording status message")
         }
 
         return .result(value: statusMessage, dialog: IntentDialog(stringLiteral: statusMessage))

--- a/CallTranscription/Intents/StartRecordingIntent.swift
+++ b/CallTranscription/Intents/StartRecordingIntent.swift
@@ -21,7 +21,7 @@ struct StartRecordingIntent: AppIntent {
     func perform() async throws -> some IntentResult {
         // Get the shared AppState instance
         let appState = try AppStateContainer.shared.requireAppState()
-        let recordingTitle = title ?? "Untitled Recording"
+        let recordingTitle = title ?? NSLocalizedString("intent.recording.defaultTitle", comment: "Default recording title")
 
         do {
             // Use startActualRecording for real recording
@@ -48,13 +48,13 @@ enum IntentError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .appNotAvailable:
-            return "Olive is not available"
+            return NSLocalizedString("intent.error.appNotAvailable", comment: "App not available error description")
         case .recordingFailed(let reason):
-            return "Recording failed: \(reason)"
+            return String(format: NSLocalizedString("intent.error.recordingFailed", comment: "Recording failed error description"), reason)
         case .notRecording:
-            return "No recording session is currently active"
+            return NSLocalizedString("intent.error.notRecording", comment: "Not recording error description")
         case .configurationFailed(let reason):
-            return "Configuration failed: \(reason)"
+            return String(format: NSLocalizedString("intent.error.configurationFailed", comment: "Configuration failed error description"), reason)
         }
     }
 }

--- a/CallTranscription/Resources/Localizable.xcstrings
+++ b/CallTranscription/Resources/Localizable.xcstrings
@@ -1902,6 +1902,102 @@
           }
         }
       }
+    },
+    "intent.status.recordingPaused": {
+      "comment": "Recording paused status message (with %@ placeholder for elapsed time)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording paused at %@"
+          }
+        }
+      }
+    },
+    "intent.status.recordingInProgress": {
+      "comment": "Recording in progress status message (with %@ placeholder for elapsed time)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording in progress: %@"
+          }
+        }
+      }
+    },
+    "intent.status.notRecording": {
+      "comment": "Not recording status message",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not recording"
+          }
+        }
+      }
+    },
+    "intent.error.appNotAvailable": {
+      "comment": "App not available error description",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive is not available"
+          }
+        }
+      }
+    },
+    "intent.error.recordingFailed": {
+      "comment": "Recording failed error description (with %@ placeholder for reason)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording failed: %@"
+          }
+        }
+      }
+    },
+    "intent.error.notRecording": {
+      "comment": "Not recording error description",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No recording session is currently active"
+          }
+        }
+      }
+    },
+    "intent.error.configurationFailed": {
+      "comment": "Configuration failed error description (with %@ placeholder for reason)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration failed: %@"
+          }
+        }
+      }
+    },
+    "intent.recording.defaultTitle": {
+      "comment": "Default recording title",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untitled Recording"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/CallTranscriptionTests/Localization/IntentMessageLocalizationTests.swift
+++ b/CallTranscriptionTests/Localization/IntentMessageLocalizationTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import CallTranscription
+
+/// Tests for Intent message localization.
+///
+/// These tests verify that all user-facing strings in App Intents
+/// (status messages, error messages, default values) are properly localized.
+final class IntentMessageLocalizationTests: XCTestCase {
+
+    // MARK: - Recording Status Messages Tests
+
+    func testRecordingPausedStatusIsLocalized() {
+        let key = "intent.status.recordingPaused"
+        let localizedValue = NSLocalizedString(key, comment: "Recording paused status message")
+
+        XCTAssertNotEqual(localizedValue, key, "Recording paused status should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Recording paused status should not be empty")
+    }
+
+    func testRecordingInProgressStatusIsLocalized() {
+        let key = "intent.status.recordingInProgress"
+        let localizedValue = NSLocalizedString(key, comment: "Recording in progress status message")
+
+        XCTAssertNotEqual(localizedValue, key, "Recording in progress status should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Recording in progress status should not be empty")
+    }
+
+    func testNotRecordingStatusIsLocalized() {
+        let key = "intent.status.notRecording"
+        let localizedValue = NSLocalizedString(key, comment: "Not recording status message")
+
+        XCTAssertNotEqual(localizedValue, key, "Not recording status should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Not recording status should not be empty")
+    }
+
+    // MARK: - IntentError Messages Tests
+
+    func testAppNotAvailableErrorIsLocalized() {
+        let error = IntentError.appNotAvailable
+        XCTAssertNotNil(error.errorDescription, "Error description should not be nil")
+        XCTAssertFalse(error.errorDescription!.isEmpty, "Error description should not be empty")
+    }
+
+    func testRecordingFailedErrorIsLocalized() {
+        let error = IntentError.recordingFailed("Test reason")
+        XCTAssertNotNil(error.errorDescription, "Error description should not be nil")
+        XCTAssertFalse(error.errorDescription!.isEmpty, "Error description should not be empty")
+        XCTAssertTrue(error.errorDescription!.contains("Test reason"), "Error should include the reason")
+    }
+
+    func testNotRecordingErrorIsLocalized() {
+        let error = IntentError.notRecording
+        XCTAssertNotNil(error.errorDescription, "Error description should not be nil")
+        XCTAssertFalse(error.errorDescription!.isEmpty, "Error description should not be empty")
+    }
+
+    func testConfigurationFailedErrorIsLocalized() {
+        let error = IntentError.configurationFailed("Test reason")
+        XCTAssertNotNil(error.errorDescription, "Error description should not be nil")
+        XCTAssertFalse(error.errorDescription!.isEmpty, "Error description should not be empty")
+        XCTAssertTrue(error.errorDescription!.contains("Test reason"), "Error should include the reason")
+    }
+
+    // MARK: - Default Value Tests
+
+    func testUntitledRecordingDefaultIsLocalized() {
+        let key = "intent.recording.defaultTitle"
+        let localizedValue = NSLocalizedString(key, comment: "Default recording title")
+
+        XCTAssertNotEqual(localizedValue, key, "Default recording title should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Default recording title should not be empty")
+    }
+}


### PR DESCRIPTION
## Summary

Implements comprehensive localization for all user-facing Intent messages, enabling full internationalization support for Shortcuts/Siri interactions.

**Scope:**
- GetRecordingStatusIntent: 3 recording status messages
- IntentError enum: 4 error descriptions
- StartRecordingIntent: 1 default recording title

**TDD Methodology:**
- ✅ Tests written first (committed separately)
- ✅ All 8 tests passing
- ✅ Build succeeds with no errors

**Changes:**
- Added 8 Intent message keys to String Catalog with format string placeholders
- Updated GetRecordingStatusIntent to use localized status messages
- Updated IntentError enum to use NSLocalizedString for error descriptions
- Updated StartRecordingIntent default title to use localized string
- Proper string formatting for status messages with elapsed time

**Testing:**
- 8/8 tests passing in IntentMessageLocalizationTests
- Verified all messages return non-nil, non-empty localized strings
- Build succeeds with no warnings or errors
- No regressions in existing functionality

## Impact

- Continues Phase 2B: Business logic localization
- All user-facing Intent messages now externalized and ready for translation
- Total localization keys: 164 (102 UI + 54 errors + 8 intents)
- Enables multi-language support for Shortcuts and Siri

## Related Issues

- Part of #46 (Comprehensive localization/internationalization support)
- Builds on Phase 2A (PRs #96-#100) and Phase 2B PR1 (#101)
- Second of 4 PRs for business logic localization