### PR TITLE
feat: localize configuration validation messages (Phase 2B PR3)

### DIFF
--- a/CallTranscription/Intents/ConfigureSettingsIntent.swift
+++ b/CallTranscription/Intents/ConfigureSettingsIntent.swift
@@ -11,13 +11,14 @@ private func validateFolderPath(_ path: String) throws -> String {
     let dangerousPaths = ["/System", "/Library", "/bin", "/sbin", "/usr", "/etc", "/var", "/private"]
     for dangerousPath in dangerousPaths {
         if standardizedPath.hasPrefix(dangerousPath) {
-            throw IntentError.configurationFailed("Cannot use system directories: \(standardizedPath)")
+            let message = String(format: NSLocalizedString("config.validation.systemDirectory", comment: "System directory error message"), standardizedPath)
+            throw IntentError.configurationFailed(message)
         }
     }
 
     // Check if path contains path traversal sequences
     if standardizedPath.contains("..") {
-        throw IntentError.configurationFailed("Path contains invalid traversal sequences")
+        throw IntentError.configurationFailed(NSLocalizedString("config.validation.pathTraversal", comment: "Path traversal error message"))
     }
 
     let fileManager = FileManager.default
@@ -27,19 +28,22 @@ private func validateFolderPath(_ path: String) throws -> String {
     if fileManager.fileExists(atPath: standardizedPath, isDirectory: &isDirectory) {
         // Ensure it's a directory
         guard isDirectory.boolValue else {
-            throw IntentError.configurationFailed("Path exists but is not a directory: \(standardizedPath)")
+            let message = String(format: NSLocalizedString("config.validation.notDirectory", comment: "Not a directory error message"), standardizedPath)
+            throw IntentError.configurationFailed(message)
         }
 
         // Check if writable
         guard fileManager.isWritableFile(atPath: standardizedPath) else {
-            throw IntentError.configurationFailed("Directory is not writable: \(standardizedPath)")
+            let message = String(format: NSLocalizedString("config.validation.notWritable", comment: "Directory not writable error message"), standardizedPath)
+            throw IntentError.configurationFailed(message)
         }
     } else {
         // Path doesn't exist - try to create it
         do {
             try fileManager.createDirectory(atPath: standardizedPath, withIntermediateDirectories: true, attributes: nil)
         } catch {
-            throw IntentError.configurationFailed("Cannot create directory: \(standardizedPath) - \(error.localizedDescription)")
+            let message = String(format: NSLocalizedString("config.validation.cannotCreateDirectory", comment: "Cannot create directory error message"), standardizedPath, error.localizedDescription)
+            throw IntentError.configurationFailed(message)
         }
     }
 
@@ -56,19 +60,22 @@ private func validateScriptPath(_ path: String) throws -> String {
 
     // Check if file exists
     guard fileManager.fileExists(atPath: standardizedPath) else {
-        throw IntentError.configurationFailed("Script file does not exist: \(standardizedPath)")
+        let message = String(format: NSLocalizedString("config.validation.scriptNotFound", comment: "Script not found error message"), standardizedPath)
+        throw IntentError.configurationFailed(message)
     }
 
     // Check if it's a regular file (not a directory)
     var isDirectory: ObjCBool = false
     fileManager.fileExists(atPath: standardizedPath, isDirectory: &isDirectory)
     guard !isDirectory.boolValue else {
-        throw IntentError.configurationFailed("Script path is a directory, not a file: \(standardizedPath)")
+        let message = String(format: NSLocalizedString("config.validation.scriptIsDirectory", comment: "Script is directory error message"), standardizedPath)
+        throw IntentError.configurationFailed(message)
     }
 
     // Check if executable
     guard fileManager.isExecutableFile(atPath: standardizedPath) else {
-        throw IntentError.configurationFailed("Script file is not executable: \(standardizedPath)")
+        let message = String(format: NSLocalizedString("config.validation.scriptNotExecutable", comment: "Script not executable error message"), standardizedPath)
+        throw IntentError.configurationFailed(message)
     }
 
     return standardizedPath

--- a/CallTranscription/Resources/Localizable.xcstrings
+++ b/CallTranscription/Resources/Localizable.xcstrings
@@ -1998,6 +1998,102 @@
           }
         }
       }
+    },
+    "config.validation.systemDirectory": {
+      "comment": "System directory error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot use system directories: %@"
+          }
+        }
+      }
+    },
+    "config.validation.pathTraversal": {
+      "comment": "Path traversal error message",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path contains invalid traversal sequences"
+          }
+        }
+      }
+    },
+    "config.validation.notDirectory": {
+      "comment": "Not a directory error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path exists but is not a directory: %@"
+          }
+        }
+      }
+    },
+    "config.validation.notWritable": {
+      "comment": "Directory not writable error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Directory is not writable: %@"
+          }
+        }
+      }
+    },
+    "config.validation.cannotCreateDirectory": {
+      "comment": "Cannot create directory error message (with %@ placeholders for path and error)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot create directory: %@ - %@"
+          }
+        }
+      }
+    },
+    "config.validation.scriptNotFound": {
+      "comment": "Script not found error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Script file does not exist: %@"
+          }
+        }
+      }
+    },
+    "config.validation.scriptIsDirectory": {
+      "comment": "Script is directory error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Script path is a directory, not a file: %@"
+          }
+        }
+      }
+    },
+    "config.validation.scriptNotExecutable": {
+      "comment": "Script not executable error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Script file is not executable: %@"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/CallTranscriptionTests/Localization/ConfigValidationLocalizationTests.swift
+++ b/CallTranscriptionTests/Localization/ConfigValidationLocalizationTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import CallTranscription
+
+/// Tests for configuration validation message localization.
+///
+/// These tests verify that all validation error messages in ConfigureSettingsIntent
+/// are properly localized for folder and script path validation.
+final class ConfigValidationLocalizationTests: XCTestCase {
+
+    // MARK: - Folder Path Validation Tests
+
+    func testSystemDirectoryErrorIsLocalized() {
+        let key = "config.validation.systemDirectory"
+        let localizedValue = NSLocalizedString(key, comment: "System directory error message")
+
+        XCTAssertNotEqual(localizedValue, key, "System directory error should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "System directory error should not be empty")
+    }
+
+    func testPathTraversalErrorIsLocalized() {
+        let key = "config.validation.pathTraversal"
+        let localizedValue = NSLocalizedString(key, comment: "Path traversal error message")
+
+        XCTAssertNotEqual(localizedValue, key, "Path traversal error should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Path traversal error should not be empty")
+    }
+
+    func testNotDirectoryErrorIsLocalized() {
+        let key = "config.validation.notDirectory"
+        let localizedValue = NSLocalizedString(key, comment: "Not a directory error message")
+
+        XCTAssertNotEqual(localizedValue, key, "Not a directory error should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Not a directory error should not be empty")
+    }
+
+    func testNotWritableErrorIsLocalized() {
+        let key = "config.validation.notWritable"
+        let localizedValue = NSLocalizedString(key, comment: "Directory not writable error message")
+
+        XCTAssertNotEqual(localizedValue, key, "Not writable error should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Not writable error should not be empty")
+    }
+
+    func testCannotCreateDirectoryErrorIsLocalized() {
+        let key = "config.validation.cannotCreateDirectory"
+        let localizedValue = NSLocalizedString(key, comment: "Cannot create directory error message")
+
+        XCTAssertNotEqual(localizedValue, key, "Cannot create directory error should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Cannot create directory error should not be empty")
+    }
+
+    // MARK: - Script Path Validation Tests
+
+    func testScriptNotFoundErrorIsLocalized() {
+        let key = "config.validation.scriptNotFound"
+        let localizedValue = NSLocalizedString(key, comment: "Script not found error message")
+
+        XCTAssertNotEqual(localizedValue, key, "Script not found error should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script not found error should not be empty")
+    }
+
+    func testScriptIsDirectoryErrorIsLocalized() {
+        let key = "config.validation.scriptIsDirectory"
+        let localizedValue = NSLocalizedString(key, comment: "Script is directory error message")
+
+        XCTAssertNotEqual(localizedValue, key, "Script is directory error should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script is directory error should not be empty")
+    }
+
+    func testScriptNotExecutableErrorIsLocalized() {
+        let key = "config.validation.scriptNotExecutable"
+        let localizedValue = NSLocalizedString(key, comment: "Script not executable error message")
+
+        XCTAssertNotEqual(localizedValue, key, "Script not executable error should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Script not executable error should not be empty")
+    }
+}


### PR DESCRIPTION
## Summary

Implements comprehensive localization for all configuration validation error messages in ConfigureSettingsIntent, enabling full internationalization support for settings validation.

**Scope:**
- Folder path validation: 5 error messages
- Script path validation: 3 error messages
- All validation errors thrown via IntentError.configurationFailed

**TDD Methodology:**
- ✅ Tests written first (committed separately)
- ✅ All 8 tests passing
- ✅ Build succeeds with no errors

**Changes:**
- Added 8 configuration validation keys to String Catalog with format string placeholders
- Updated validateFolderPath() to use localized validation messages
- Updated validateScriptPath() to use localized validation messages
- Proper string formatting for errors with path and error details

**Testing:**
- 8/8 tests passing in ConfigValidationLocalizationTests
- Verified all messages return non-nil, non-empty localized strings
- Build succeeds with no warnings or errors
- No regressions in existing functionality

## Impact

- Continues Phase 2B: Business logic localization
- All configuration validation messages now externalized and ready for translation
- Total localization keys: 172 (102 UI + 54 errors + 8 intents + 8 validation)
- Enables multi-language support for configuration validation

## Related Issues

- Part of #46 (Comprehensive localization/internationalization support)
- Builds on Phase 2A (PRs #96-#100) and Phase 2B PRs (#101-#102)
- Third of 4 PRs for business logic localization