### PR TITLE
feat: localize transcript file formatting (Phase 2B PR4)

### DIFF
--- a/CallTranscription/Resources/Localizable.xcstrings
+++ b/CallTranscription/Resources/Localizable.xcstrings
@@ -2094,6 +2094,54 @@
           }
         }
       }
+    },
+    "transcript.header.title": {
+      "comment": "Transcript file header title",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive - Call Transcription Transcript"
+          }
+        }
+      }
+    },
+    "transcript.header.dateLabel": {
+      "comment": "Date label in transcript header",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date: "
+          }
+        }
+      }
+    },
+    "transcript.header.titleLabel": {
+      "comment": "Title label in transcript header",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Title: "
+          }
+        }
+      }
+    },
+    "transcript.header.separator": {
+      "comment": "Separator line in transcript header",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "================================================================================"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/CallTranscription/Storage/TranscriptWriter.swift
+++ b/CallTranscription/Storage/TranscriptWriter.swift
@@ -87,21 +87,21 @@ public final class TranscriptWriter {
 
     /// Generates a formatted header for the transcript file.
     private static func generateHeader(title: String?, date: Date) -> String {
-        var header = "Olive - Call Transcription Transcript\n"
+        var header = NSLocalizedString("transcript.header.title", comment: "Transcript file header title") + "\n"
 
         // Add date
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .long
         dateFormatter.timeStyle = .none
-        header += "Date: \(dateFormatter.string(from: date))\n"
+        header += NSLocalizedString("transcript.header.dateLabel", comment: "Date label in transcript header") + "\(dateFormatter.string(from: date))\n"
 
         // Add title if provided
         if let title = title, !title.isEmpty {
-            header += "Title: \(title)\n"
+            header += NSLocalizedString("transcript.header.titleLabel", comment: "Title label in transcript header") + "\(title)\n"
         }
 
         // Add separator
-        header += "================================================================================\n\n"
+        header += NSLocalizedString("transcript.header.separator", comment: "Separator line in transcript header") + "\n\n"
 
         return header
     }

--- a/CallTranscriptionTests/Localization/TranscriptFormattingLocalizationTests.swift
+++ b/CallTranscriptionTests/Localization/TranscriptFormattingLocalizationTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import CallTranscription
+
+/// Tests for transcript file formatting string localization.
+///
+/// These tests verify that all user-facing strings in transcript file headers
+/// and formatting are properly localized.
+final class TranscriptFormattingLocalizationTests: XCTestCase {
+
+    // MARK: - Header String Tests
+
+    func testHeaderTitleIsLocalized() {
+        let key = "transcript.header.title"
+        let localizedValue = NSLocalizedString(key, comment: "Transcript file header title")
+
+        XCTAssertNotEqual(localizedValue, key, "Header title should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Header title should not be empty")
+    }
+
+    func testDateLabelIsLocalized() {
+        let key = "transcript.header.dateLabel"
+        let localizedValue = NSLocalizedString(key, comment: "Date label in transcript header")
+
+        XCTAssertNotEqual(localizedValue, key, "Date label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Date label should not be empty")
+    }
+
+    func testTitleLabelIsLocalized() {
+        let key = "transcript.header.titleLabel"
+        let localizedValue = NSLocalizedString(key, comment: "Title label in transcript header")
+
+        XCTAssertNotEqual(localizedValue, key, "Title label should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Title label should not be empty")
+    }
+
+    func testSeparatorIsLocalized() {
+        let key = "transcript.header.separator"
+        let localizedValue = NSLocalizedString(key, comment: "Separator line in transcript header")
+
+        XCTAssertNotEqual(localizedValue, key, "Separator should be localized")
+        XCTAssertFalse(localizedValue.isEmpty, "Separator should not be empty")
+    }
+}


### PR DESCRIPTION
## Summary

Implements comprehensive localization for all transcript file header formatting strings, completing Phase 2B (business logic localization).

**Scope:**
- Transcript header title
- Date label prefix
- Title label prefix
- Header separator line

**TDD Methodology:**
- ✅ Tests written first (committed separately)
- ✅ All 4 tests passing
- ✅ Build succeeds with no errors

**Changes:**
- Added 4 transcript formatting keys to String Catalog
- Updated TranscriptWriter.generateHeader() to use localized strings
- All transcript file headers now use localized formatting

**Testing:**
- 4/4 tests passing in TranscriptFormattingLocalizationTests
- Verified all strings return non-nil, non-empty localized strings
- Build succeeds with no warnings or errors
- No regressions in existing functionality

## Impact

- **Completes Phase 2B: Business logic localization** ✅
- All transcript formatting strings now externalized and ready for translation
- **Total localization keys: 176** (102 UI + 74 business logic)
  - UI: 102 keys
  - Error messages: 54 keys
  - Intent messages: 8 keys
  - Configuration validation: 8 keys
  - Transcript formatting: 4 keys
- Full i18n support for all user-facing strings

## Related Issues

- Part of #46 (Comprehensive localization/internationalization support)
- Builds on Phase 2A (PRs #96-#100) and Phase 2B PRs (#101-#103)
- **Final PR for Phase 2B** - completes business logic localization
- Next: Phase 3 (translations for 6 languages)