### PR TITLE
revert: Restore AAC bitrate to 128kbps

### DIFF
--- a/CallTranscription/Audio/AudioFileWriter.swift
+++ b/CallTranscription/Audio/AudioFileWriter.swift
@@ -67,12 +67,11 @@ public final class AudioFileWriter {
         do {
             if format == .aac {
                 // For M4A/AAC: 48kHz mono for CoreAudio Process Tap compatibility
-                // Using 256kbps for higher quality (Issue #137)
                 let settings: [String: Any] = [
                     AVFormatIDKey: kAudioFormatMPEG4AAC,
                     AVSampleRateKey: 48000,
                     AVNumberOfChannelsKey: 1,
-                    AVEncoderBitRateKey: 256000  // Increased from 128000 to 256000 for better quality
+                    AVEncoderBitRateKey: 128000
                 ]
 
                 // Create the audio file

--- a/CallTranscriptionTests/Audio/AudioQualityTests.swift
+++ b/CallTranscriptionTests/Audio/AudioQualityTests.swift
@@ -263,13 +263,13 @@ final class AudioQualityTests: XCTestCase {
         // Verify file was created
         XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
 
-        // Verify file has reasonable size (higher bitrate = larger file)
+        // Verify file has reasonable size
         let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
         let fileSize = attributes[.size] as! UInt64
 
-        // With 256kbps encoding and ~0.085 seconds of audio, expect > 2KB
-        // (rough calculation: 256000 bits/sec * 0.085 sec / 8 = ~2.7KB)
-        XCTAssertGreaterThan(fileSize, 2000, "File seems too small for high-quality encoding")
+        // With 128kbps encoding and ~0.085 seconds of audio, expect > 1KB
+        // (rough calculation: 128000 bits/sec * 0.085 sec / 8 = ~1.36KB)
+        XCTAssertGreaterThan(fileSize, 1000, "File seems too small for AAC encoding")
     }
 
     func testAudioFileWriterMaintains48kHzSampleRate() async throws {


### PR DESCRIPTION
## Summary

Revert AAC encoding bitrate from 256kbps back to 128kbps. The 128kbps bitrate is sufficient quality for voice recordings.

## Changes

- **AudioFileWriter.swift**: Change `AVEncoderBitRateKey` from 256000 to 128000
- **AudioQualityTests.swift**: Update file size expectations and comments to reflect 128kbps encoding

## Audio Quality Improvements Retained

All other audio quality improvements from PR #138 remain in place:
- ✅ High-quality sample rate conversion (mastering algorithm with `.max` quality)
- ✅ Proper stereo-to-mono downmixing using (L+R)/sqrt(2) formula
- ✅ Enhanced format conversion logging for diagnostics
- ✅ Separate conversion paths to reduce cumulative degradation

## Rationale

128kbps AAC provides excellent quality for voice recordings while using less disk space and encoding resources. The primary audio quality issues addressed in #137 were related to:
- Sample rate conversion quality
- Stereo-to-mono downmixing  
- Lack of diagnostic logging

These core issues have been fixed with the other improvements, making the higher bitrate unnecessary for this use case.

## Test Results

✅ All 10 AudioQualityTests passing with 128kbps:
- Format conversion tests
- Stereo downmix tests
- Sample rate conversion quality tests
- End-to-end pipeline tests

## Impact

- Smaller file sizes (~50% reduction vs 256kbps)
- Lower CPU usage during encoding
- No noticeable quality difference for voice content
- All quality improvements from #137 preserved