### PR TITLE
feat: Optimize CI workflow to skip XcodeGen when not needed (Issue #110)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,30 +52,29 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app
 
-      # Cache XcodeGen binary installation (version-based key, not project.yml dependent)
+      # Cache XcodeGen binary with version-based key (not project.yml dependent)
+      # This caches the XcodeGen tool itself, which doesn't change when project.yml changes
       - name: Cache XcodeGen
         id: cache-xcodegen
         uses: actions/cache@v4
         with:
           path: /opt/homebrew/bin/xcodegen
           key: ${{ runner.os }}-xcodegen-2.40.1
-          restore-keys: |
-            ${{ runner.os }}-xcodegen-
 
       # Only install XcodeGen if not cached
       - name: Install XcodeGen
         if: steps.cache-xcodegen.outputs.cache-hit != 'true'
         run: brew install xcodegen
 
-      # Cache the generated Xcode project
+      # Cache generated Xcode project with hash of project.yml
+      # No restore-keys ensures strict invalidation when project.yml changes
+      # This prevents using outdated cached projects when configuration changes
       - name: Cache Xcode project
         id: cache-xcodeproj
         uses: actions/cache@v4
         with:
           path: Olive.xcodeproj
           key: ${{ runner.os }}-xcodeproj-${{ hashFiles('project.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-xcodeproj-
 
       # Only regenerate if project.yml changed or cache miss
       - name: Generate Xcode project
@@ -84,9 +83,12 @@ jobs:
           if [ -f "project.yml" ]; then
             echo "Regenerating Xcode project (project.yml changed or cache miss)"
             xcodegen generate
+            # Store hash of project.yml for validation
+            shasum -a 256 project.yml | cut -d' ' -f1 > Olive.xcodeproj/.project_yml_hash
           fi
 
-      # Validate that project is up-to-date (for cache hits)
+      # Validate that cached project is up-to-date
+      # Exit with error if cache claims hit but project is stale
       - name: Validate Xcode project
         if: steps.cache-xcodeproj.outputs.cache-hit == 'true'
         run: |
@@ -144,30 +146,29 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app
 
-      # Cache XcodeGen binary installation (version-based key, not project.yml dependent)
+      # Cache XcodeGen binary with version-based key (not project.yml dependent)
+      # This caches the XcodeGen tool itself, which doesn't change when project.yml changes
       - name: Cache XcodeGen
         id: cache-xcodegen
         uses: actions/cache@v4
         with:
           path: /opt/homebrew/bin/xcodegen
           key: ${{ runner.os }}-xcodegen-2.40.1
-          restore-keys: |
-            ${{ runner.os }}-xcodegen-
 
       # Only install XcodeGen if not cached
       - name: Install XcodeGen
         if: steps.cache-xcodegen.outputs.cache-hit != 'true'
         run: brew install xcodegen
 
-      # Cache the generated Xcode project
+      # Cache generated Xcode project with hash of project.yml
+      # No restore-keys ensures strict invalidation when project.yml changes
+      # This prevents using outdated cached projects when configuration changes
       - name: Cache Xcode project
         id: cache-xcodeproj
         uses: actions/cache@v4
         with:
           path: Olive.xcodeproj
           key: ${{ runner.os }}-xcodeproj-${{ hashFiles('project.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-xcodeproj-
 
       # Only regenerate if project.yml changed or cache miss
       - name: Generate Xcode project
@@ -176,9 +177,12 @@ jobs:
           if [ -f "project.yml" ]; then
             echo "Regenerating Xcode project (project.yml changed or cache miss)"
             xcodegen generate
+            # Store hash of project.yml for validation
+            shasum -a 256 project.yml | cut -d' ' -f1 > Olive.xcodeproj/.project_yml_hash
           fi
 
-      # Validate that project is up-to-date (for cache hits)
+      # Validate that cached project is up-to-date
+      # Exit with error if cache claims hit but project is stale
       - name: Validate Xcode project
         if: steps.cache-xcodeproj.outputs.cache-hit == 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,48 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app
 
+      # Cache XcodeGen binary installation
+      - name: Cache XcodeGen
+        id: cache-xcodegen
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/bin/xcodegen
+            /opt/homebrew/bin/xcodegen
+          key: ${{ runner.os }}-xcodegen-${{ hashFiles('**/project.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-xcodegen-
+
+      # Only install XcodeGen if not cached
+      - name: Install XcodeGen
+        if: steps.cache-xcodegen.outputs.cache-hit != 'true'
+        run: brew install xcodegen
+
+      # Cache the generated Xcode project
+      - name: Cache Xcode project
+        id: cache-xcodeproj
+        uses: actions/cache@v4
+        with:
+          path: Olive.xcodeproj
+          key: ${{ runner.os }}-xcodeproj-${{ hashFiles('project.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-xcodeproj-
+
+      # Only regenerate if project.yml changed or cache miss
       - name: Generate Xcode project
+        if: steps.cache-xcodeproj.outputs.cache-hit != 'true'
         run: |
           if [ -f "project.yml" ]; then
-            brew install xcodegen
+            echo "Regenerating Xcode project (project.yml changed or cache miss)"
             xcodegen generate
           fi
+
+      # Validate that project is up-to-date (for cache hits)
+      - name: Validate Xcode project
+        if: steps.cache-xcodeproj.outputs.cache-hit == 'true'
+        run: |
+          echo "Using cached Xcode project (project.yml unchanged)"
+          ./scripts/check-xcodegen-needed.sh || echo "Project is up to date"
 
       - name: Build ${{ matrix.configuration }}
         run: |
@@ -92,10 +128,39 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app
 
+      # Cache XcodeGen binary installation
+      - name: Cache XcodeGen
+        id: cache-xcodegen
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/bin/xcodegen
+            /opt/homebrew/bin/xcodegen
+          key: ${{ runner.os }}-xcodegen-${{ hashFiles('**/project.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-xcodegen-
+
+      # Only install XcodeGen if not cached
+      - name: Install XcodeGen
+        if: steps.cache-xcodegen.outputs.cache-hit != 'true'
+        run: brew install xcodegen
+
+      # Cache the generated Xcode project
+      - name: Cache Xcode project
+        id: cache-xcodeproj
+        uses: actions/cache@v4
+        with:
+          path: Olive.xcodeproj
+          key: ${{ runner.os }}-xcodeproj-${{ hashFiles('project.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-xcodeproj-
+
+      # Only regenerate if project.yml changed or cache miss
       - name: Generate Xcode project
+        if: steps.cache-xcodeproj.outputs.cache-hit != 'true'
         run: |
           if [ -f "project.yml" ]; then
-            brew install xcodegen
+            echo "Regenerating Xcode project (project.yml changed or cache miss)"
             xcodegen generate
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,14 @@ jobs:
 
       # Cache XcodeGen binary with version-based key (not project.yml dependent)
       # This caches the XcodeGen tool itself, which doesn't change when project.yml changes
+      # Using both Intel and Apple Silicon paths for cross-platform compatibility
       - name: Cache XcodeGen
         id: cache-xcodegen
         uses: actions/cache@v4
         with:
-          path: /opt/homebrew/bin/xcodegen
+          path: |
+            /opt/homebrew/bin/xcodegen
+            /usr/local/bin/xcodegen
           key: ${{ runner.os }}-xcodegen-2.40.1
 
       # Only install XcodeGen if not cached
@@ -83,8 +86,8 @@ jobs:
           if [ -f "project.yml" ]; then
             echo "Regenerating Xcode project (project.yml changed or cache miss)"
             xcodegen generate
-            # Store hash of project.yml for validation
-            shasum -a 256 project.yml | cut -d' ' -f1 > Olive.xcodeproj/.project_yml_hash
+            # Store hash of project.yml for validation (more reliable than timestamps in CI)
+            shasum -a 256 project.yml | awk '{print $1}' > Olive.xcodeproj/.project_yml_hash
           fi
 
       # Validate that cached project is up-to-date
@@ -148,11 +151,14 @@ jobs:
 
       # Cache XcodeGen binary with version-based key (not project.yml dependent)
       # This caches the XcodeGen tool itself, which doesn't change when project.yml changes
+      # Using both Intel and Apple Silicon paths for cross-platform compatibility
       - name: Cache XcodeGen
         id: cache-xcodegen
         uses: actions/cache@v4
         with:
-          path: /opt/homebrew/bin/xcodegen
+          path: |
+            /opt/homebrew/bin/xcodegen
+            /usr/local/bin/xcodegen
           key: ${{ runner.os }}-xcodegen-2.40.1
 
       # Only install XcodeGen if not cached
@@ -177,8 +183,8 @@ jobs:
           if [ -f "project.yml" ]; then
             echo "Regenerating Xcode project (project.yml changed or cache miss)"
             xcodegen generate
-            # Store hash of project.yml for validation
-            shasum -a 256 project.yml | cut -d' ' -f1 > Olive.xcodeproj/.project_yml_hash
+            # Store hash of project.yml for validation (more reliable than timestamps in CI)
+            shasum -a 256 project.yml | awk '{print $1}' > Olive.xcodeproj/.project_yml_hash
           fi
 
       # Validate that cached project is up-to-date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,21 @@ jobs:
         run: |
           python3 scripts/validate_localizations.py
 
+  test-ci-optimization:
+    name: Test CI Optimization Scripts
+    runs-on: macos-15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Test XcodeGen check logic
+        run: |
+          ./scripts/tests/test-xcodegen-check.sh
+
+      - name: Test CI workflow configuration
+        run: |
+          ./scripts/tests/test-ci-workflow.sh
+
   build-and-test:
     name: Build and Test
     runs-on: macos-15
@@ -37,15 +52,13 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app
 
-      # Cache XcodeGen binary installation
+      # Cache XcodeGen binary installation (version-based key, not project.yml dependent)
       - name: Cache XcodeGen
         id: cache-xcodegen
         uses: actions/cache@v4
         with:
-          path: |
-            /usr/local/bin/xcodegen
-            /opt/homebrew/bin/xcodegen
-          key: ${{ runner.os }}-xcodegen-${{ hashFiles('**/project.yml') }}
+          path: /opt/homebrew/bin/xcodegen
+          key: ${{ runner.os }}-xcodegen-2.40.1
           restore-keys: |
             ${{ runner.os }}-xcodegen-
 
@@ -78,7 +91,10 @@ jobs:
         if: steps.cache-xcodeproj.outputs.cache-hit == 'true'
         run: |
           echo "Using cached Xcode project (project.yml unchanged)"
-          ./scripts/check-xcodegen-needed.sh || echo "Project is up to date"
+          if ./scripts/check-xcodegen-needed.sh; then
+            echo "ERROR: Cached project is out of date but cache indicated a hit"
+            exit 1
+          fi
 
       - name: Build ${{ matrix.configuration }}
         run: |
@@ -128,15 +144,13 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app
 
-      # Cache XcodeGen binary installation
+      # Cache XcodeGen binary installation (version-based key, not project.yml dependent)
       - name: Cache XcodeGen
         id: cache-xcodegen
         uses: actions/cache@v4
         with:
-          path: |
-            /usr/local/bin/xcodegen
-            /opt/homebrew/bin/xcodegen
-          key: ${{ runner.os }}-xcodegen-${{ hashFiles('**/project.yml') }}
+          path: /opt/homebrew/bin/xcodegen
+          key: ${{ runner.os }}-xcodegen-2.40.1
           restore-keys: |
             ${{ runner.os }}-xcodegen-
 
@@ -162,6 +176,16 @@ jobs:
           if [ -f "project.yml" ]; then
             echo "Regenerating Xcode project (project.yml changed or cache miss)"
             xcodegen generate
+          fi
+
+      # Validate that project is up-to-date (for cache hits)
+      - name: Validate Xcode project
+        if: steps.cache-xcodeproj.outputs.cache-hit == 'true'
+        run: |
+          echo "Using cached Xcode project (project.yml unchanged)"
+          if ./scripts/check-xcodegen-needed.sh; then
+            echo "ERROR: Cached project is out of date but cache indicated a hit"
+            exit 1
           fi
 
       - name: Build Release

--- a/scripts/check-xcodegen-needed.sh
+++ b/scripts/check-xcodegen-needed.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Check if XcodeGen needs to run
+# Returns 0 (true) if XcodeGen needs to run, 1 (false) otherwise
+
+should_regenerate_xcode_project() {
+    local project_yml="project.yml"
+    local xcodeproj="Olive.xcodeproj"
+    
+    # If project.yml doesn't exist, something is wrong - regenerate
+    if [ ! -f "$project_yml" ]; then
+        echo "⚠️  project.yml not found - regeneration needed"
+        return 0
+    fi
+    
+    # If xcodeproj doesn't exist, we need to generate it
+    if [ ! -d "$xcodeproj" ]; then
+        echo "⚠️  Olive.xcodeproj not found - regeneration needed"
+        return 0
+    fi
+    
+    # Check if project.yml is newer than xcodeproj
+    if [ "$project_yml" -nt "$xcodeproj/project.pbxproj" ]; then
+        echo "⚠️  project.yml is newer than Olive.xcodeproj - regeneration needed"
+        return 0
+    fi
+    
+    echo "✓ Olive.xcodeproj is up to date - skipping regeneration"
+    return 1
+}
+
+# If script is being executed (not sourced), run the check
+if [ "${BASH_SOURCE[0]}" -ef "$0" ]; then
+    should_regenerate_xcode_project
+fi

--- a/scripts/check-xcodegen-needed.sh
+++ b/scripts/check-xcodegen-needed.sh
@@ -5,6 +5,7 @@
 should_regenerate_xcode_project() {
     local project_yml="project.yml"
     local xcodeproj="Olive.xcodeproj"
+    local pbxproj="$xcodeproj/project.pbxproj"
     
     # If project.yml doesn't exist, something is wrong - regenerate
     if [ ! -f "$project_yml" ]; then
@@ -18,10 +19,45 @@ should_regenerate_xcode_project() {
         return 0
     fi
     
-    # Check if project.yml is newer than xcodeproj
-    if [ "$project_yml" -nt "$xcodeproj/project.pbxproj" ]; then
+    # If project.pbxproj doesn't exist or is corrupted, regenerate
+    if [ ! -f "$pbxproj" ] || [ ! -r "$pbxproj" ]; then
+        echo "⚠️  project.pbxproj missing or unreadable - regeneration needed"
+        return 0
+    fi
+    
+    # Primary check: timestamp comparison
+    # Note: git doesn't preserve modification times, so this may be unreliable in CI
+    if [ "$project_yml" -nt "$pbxproj" ]; then
         echo "⚠️  project.yml is newer than Olive.xcodeproj - regeneration needed"
         return 0
+    fi
+    
+    # Fallback check: hash-based validation
+    # More reliable in CI environments where timestamps are unreliable
+    # We hash project.yml and compare it to a stored hash in the xcodeproj
+    # If the hash file doesn't exist or doesn't match, regenerate
+    local hash_file="$xcodeproj/.project_yml_hash"
+    local current_hash
+    current_hash=$(shasum -a 256 "$project_yml" | cut -d' ' -f1)
+    
+    if [ -f "$hash_file" ]; then
+        local stored_hash
+        stored_hash=$(cat "$hash_file")
+        if [ "$current_hash" != "$stored_hash" ]; then
+            echo "⚠️  project.yml hash changed - regeneration needed"
+            return 0
+        fi
+    else
+        # Hash file doesn't exist - store current hash for future comparisons
+        # Don't require regeneration if project is newer than yml
+        if [ "$pbxproj" -nt "$project_yml" ]; then
+            echo "$current_hash" > "$hash_file"
+            echo "✓ Olive.xcodeproj is up to date - stored hash for future validation"
+            return 1
+        else
+            echo "⚠️  Hash file missing and timestamps inconclusive - regeneration needed"
+            return 0
+        fi
     fi
     
     echo "✓ Olive.xcodeproj is up to date - skipping regeneration"

--- a/scripts/check-xcodegen-needed.sh
+++ b/scripts/check-xcodegen-needed.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Check if XcodeGen needs to run
-# Returns 0 (true) if XcodeGen needs to run, 1 (false) otherwise
+# Returns 0 (success/true) if regeneration needed, 1 (failure/false) if not needed
+# Following bash convention where 0 = true/success, 1 = false/failure
 
 should_regenerate_xcode_project() {
     local project_yml="project.yml"
@@ -25,20 +26,13 @@ should_regenerate_xcode_project() {
         return 0
     fi
     
-    # Primary check: timestamp comparison
-    # Note: git doesn't preserve modification times, so this may be unreliable in CI
-    if [ "$project_yml" -nt "$pbxproj" ]; then
-        echo "⚠️  project.yml is newer than Olive.xcodeproj - regeneration needed"
-        return 0
-    fi
-    
-    # Fallback check: hash-based validation
-    # More reliable in CI environments where timestamps are unreliable
+    # Primary check: Hash-based validation (more reliable in CI)
+    # Git doesn't preserve modification times, so timestamps are unreliable in CI
     # We hash project.yml and compare it to a stored hash in the xcodeproj
-    # If the hash file doesn't exist or doesn't match, regenerate
     local hash_file="$xcodeproj/.project_yml_hash"
     local current_hash
-    current_hash=$(shasum -a 256 "$project_yml" | cut -d' ' -f1)
+    # Use awk for safer parsing (handles special characters in paths)
+    current_hash=$(shasum -a 256 "$project_yml" | awk '{print $1}')
     
     if [ -f "$hash_file" ]; then
         local stored_hash
@@ -47,20 +41,21 @@ should_regenerate_xcode_project() {
             echo "⚠️  project.yml hash changed - regeneration needed"
             return 0
         fi
-    else
-        # Hash file doesn't exist - store current hash for future comparisons
-        # Don't require regeneration if project is newer than yml
-        if [ "$pbxproj" -nt "$project_yml" ]; then
-            echo "$current_hash" > "$hash_file"
-            echo "✓ Olive.xcodeproj is up to date - stored hash for future validation"
-            return 1
-        else
-            echo "⚠️  Hash file missing and timestamps inconclusive - regeneration needed"
-            return 0
-        fi
+        # Hash matches - project is up to date
+        echo "✓ Olive.xcodeproj is up to date - skipping regeneration"
+        return 1
     fi
     
-    echo "✓ Olive.xcodeproj is up to date - skipping regeneration"
+    # Hash file doesn't exist - fall back to timestamp check
+    # Check if project.yml is newer than xcodeproj
+    if [ "$project_yml" -nt "$pbxproj" ]; then
+        echo "⚠️  project.yml is newer than Olive.xcodeproj - regeneration needed"
+        return 0
+    fi
+    
+    # Project appears newer than yml - store hash for future comparisons
+    echo "$current_hash" > "$hash_file"
+    echo "✓ Olive.xcodeproj is up to date - stored hash for future validation"
     return 1
 }
 

--- a/scripts/tests/test-ci-workflow.sh
+++ b/scripts/tests/test-ci-workflow.sh
@@ -7,6 +7,10 @@ set -e
 TEST_PASSED=0
 TEST_FAILED=0
 
+# Get the repository root dynamically
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+
 # Colors for output
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -29,39 +33,56 @@ info() {
 }
 
 echo "Running CI workflow optimization tests..."
+echo "Repository root: $REPO_ROOT"
+echo "CI workflow: $CI_WORKFLOW"
 echo ""
 
 # Test 1: Workflow file contains caching configuration
 echo "Test 1: CI workflow uses actions/cache for XcodeGen"
-if grep -q "actions/cache" /tmp/olive-worktrees/issue-110/.github/workflows/ci.yml; then
+if grep -q "actions/cache" "$CI_WORKFLOW"; then
     pass "CI workflow includes caching step"
 else
     fail "CI workflow should include actions/cache for XcodeGen"
 fi
 
-# Test 2: Workflow file uses hash-based cache key
-echo "Test 2: Cache key includes hash of project.yml"
-if grep -q "hashFiles.*project\.yml" /tmp/olive-worktrees/issue-110/.github/workflows/ci.yml; then
-    pass "Cache key uses project.yml hash"
+# Test 2: Workflow file uses hash-based cache key for project
+echo "Test 2: Cache key includes hash of project.yml for Xcode project"
+if grep -q "hashFiles.*project\.yml" "$CI_WORKFLOW"; then
+    pass "Cache key uses project.yml hash for Xcode project"
 else
-    fail "Cache key should include hashFiles of project.yml"
+    fail "Cache key should include hashFiles of project.yml for Xcode project"
 fi
 
-# Test 3: Workflow conditionally runs XcodeGen
-echo "Test 3: XcodeGen step is conditional"
-if grep -A5 "Generate Xcode project" /tmp/olive-worktrees/issue-110/.github/workflows/ci.yml | grep -q "if:"; then
+# Test 3: XcodeGen binary cache uses version-based key (not project.yml dependent)
+echo "Test 3: XcodeGen binary cache uses version-based key"
+if grep -q "xcodegen-2\\.40\\.1" "$CI_WORKFLOW"; then
+    pass "XcodeGen cache uses version-based key"
+else
+    fail "XcodeGen cache should use version-based key, not project.yml hash"
+fi
+
+# Test 4: Workflow conditionally runs XcodeGen
+echo "Test 4: XcodeGen step is conditional"
+if grep -A5 "Generate Xcode project" "$CI_WORKFLOW" | grep -q "if:"; then
     pass "XcodeGen generation is conditional"
 else
-    info "XcodeGen generation could be conditional (optional optimization)"
+    fail "XcodeGen generation should be conditional"
 fi
 
-# Test 4: XcodeGen binary is cached
-echo "Test 4: XcodeGen binary installation is cached"
-if grep -q "cache.*xcodegen" /tmp/olive-worktrees/issue-110/.github/workflows/ci.yml || \
-   grep -q "XcodeGen" /tmp/olive-worktrees/issue-110/.github/workflows/ci.yml | head -20 | grep -q "cache"; then
-    pass "XcodeGen binary is cached"
+# Test 5: Workflow includes validation step
+echo "Test 5: Workflow validates cached project"
+if grep -q "Validate Xcode project" "$CI_WORKFLOW"; then
+    pass "Workflow includes project validation"
 else
-    fail "XcodeGen binary installation should be cached"
+    fail "Workflow should validate cached project"
+fi
+
+# Test 6: Test job exists in workflow
+echo "Test 6: CI workflow includes test job for optimization scripts"
+if grep -q "test-ci-optimization" "$CI_WORKFLOW"; then
+    pass "CI workflow runs optimization tests"
+else
+    fail "CI workflow should run test scripts"
 fi
 
 # Summary

--- a/scripts/tests/test-ci-workflow.sh
+++ b/scripts/tests/test-ci-workflow.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Test script for CI workflow optimization
+# This validates the CI workflow caching and conditional logic
+
+set -e
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+# Test helper functions
+pass() {
+    echo -e "${GREEN}✓${NC} $1"
+    TEST_PASSED=$((TEST_PASSED + 1))
+}
+
+fail() {
+    echo -e "${RED}✗${NC} $1"
+    TEST_FAILED=$((TEST_FAILED + 1))
+}
+
+info() {
+    echo -e "${YELLOW}ℹ${NC} $1"
+}
+
+echo "Running CI workflow optimization tests..."
+echo ""
+
+# Test 1: Workflow file contains caching configuration
+echo "Test 1: CI workflow uses actions/cache for XcodeGen"
+if grep -q "actions/cache" /tmp/olive-worktrees/issue-110/.github/workflows/ci.yml; then
+    pass "CI workflow includes caching step"
+else
+    fail "CI workflow should include actions/cache for XcodeGen"
+fi
+
+# Test 2: Workflow file uses hash-based cache key
+echo "Test 2: Cache key includes hash of project.yml"
+if grep -q "hashFiles.*project\.yml" /tmp/olive-worktrees/issue-110/.github/workflows/ci.yml; then
+    pass "Cache key uses project.yml hash"
+else
+    fail "Cache key should include hashFiles of project.yml"
+fi
+
+# Test 3: Workflow conditionally runs XcodeGen
+echo "Test 3: XcodeGen step is conditional"
+if grep -A5 "Generate Xcode project" /tmp/olive-worktrees/issue-110/.github/workflows/ci.yml | grep -q "if:"; then
+    pass "XcodeGen generation is conditional"
+else
+    info "XcodeGen generation could be conditional (optional optimization)"
+fi
+
+# Test 4: XcodeGen binary is cached
+echo "Test 4: XcodeGen binary installation is cached"
+if grep -q "cache.*xcodegen" /tmp/olive-worktrees/issue-110/.github/workflows/ci.yml || \
+   grep -q "XcodeGen" /tmp/olive-worktrees/issue-110/.github/workflows/ci.yml | head -20 | grep -q "cache"; then
+    pass "XcodeGen binary is cached"
+else
+    fail "XcodeGen binary installation should be cached"
+fi
+
+# Summary
+echo ""
+echo "=========================="
+echo "Test Results:"
+echo "  Passed: $TEST_PASSED"
+echo "  Failed: $TEST_FAILED"
+echo "=========================="
+
+if [ $TEST_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed!${NC}"
+    exit 1
+fi

--- a/scripts/tests/test-ci-workflow.sh
+++ b/scripts/tests/test-ci-workflow.sh
@@ -55,10 +55,10 @@ fi
 
 # Test 3: XcodeGen binary cache uses version-based key (not project.yml dependent)
 echo "Test 3: XcodeGen binary cache uses version-based key"
-if grep -q "xcodegen-2\\.40\\.1" "$CI_WORKFLOW"; then
+if grep -qE "xcodegen-[0-9]+\.[0-9]+\.[0-9]+" "$CI_WORKFLOW"; then
     pass "XcodeGen cache uses version-based key"
 else
-    fail "XcodeGen cache should use version-based key, not project.yml hash"
+    fail "XcodeGen cache should use version-based key (e.g., xcodegen-2.40.1)"
 fi
 
 # Test 4: Workflow conditionally runs XcodeGen
@@ -83,6 +83,16 @@ if grep -q "test-ci-optimization" "$CI_WORKFLOW"; then
     pass "CI workflow runs optimization tests"
 else
     fail "CI workflow should run test scripts"
+fi
+
+# Test 7: No restore-keys for Xcode project cache (strict invalidation)
+echo "Test 7: Xcode project cache has strict invalidation"
+# Count occurrences of restore-keys in the context of Xcode project cache
+# Should not have restore-keys for xcodeproj to ensure strict invalidation
+if grep -A5 "Cache Xcode project" "$CI_WORKFLOW" | grep -q "restore-keys"; then
+    fail "Xcode project cache should not have restore-keys for strict invalidation"
+else
+    pass "Xcode project cache uses strict invalidation (no restore-keys)"
 fi
 
 # Summary

--- a/scripts/tests/test-xcodegen-check.sh
+++ b/scripts/tests/test-xcodegen-check.sh
@@ -7,6 +7,9 @@ set -e
 TEST_PASSED=0
 TEST_FAILED=0
 
+# Get the repository root dynamically
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
 # Colors for output
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -28,6 +31,7 @@ TEST_DIR=$(mktemp -d)
 cd "$TEST_DIR"
 
 echo "Running XcodeGen optimization tests..."
+echo "Repository root: $REPO_ROOT"
 echo "Test directory: $TEST_DIR"
 echo ""
 
@@ -36,7 +40,7 @@ echo "Test 1: Returns true when project.yml is newer than .xcodeproj"
 mkdir -p Olive.xcodeproj
 touch -t 202401010000 Olive.xcodeproj/project.pbxproj
 touch -t 202401020000 project.yml
-if source /tmp/olive-worktrees/issue-110/scripts/check-xcodegen-needed.sh && should_regenerate_xcode_project; then
+if source "$REPO_ROOT/scripts/check-xcodegen-needed.sh" && should_regenerate_xcode_project; then
     pass "Detects project.yml is newer"
 else
     fail "Should detect project.yml is newer"
@@ -46,7 +50,7 @@ fi
 echo "Test 2: Returns false when .xcodeproj is newer than project.yml"
 touch -t 202401020000 Olive.xcodeproj/project.pbxproj
 touch -t 202401010000 project.yml
-if source /tmp/olive-worktrees/issue-110/scripts/check-xcodegen-needed.sh && ! should_regenerate_xcode_project; then
+if source "$REPO_ROOT/scripts/check-xcodegen-needed.sh" && ! should_regenerate_xcode_project; then
     pass "Detects .xcodeproj is up to date"
 else
     fail "Should detect .xcodeproj is up to date"
@@ -56,7 +60,7 @@ fi
 echo "Test 3: Returns true when .xcodeproj doesn't exist"
 rm -rf Olive.xcodeproj
 touch project.yml
-if source /tmp/olive-worktrees/issue-110/scripts/check-xcodegen-needed.sh && should_regenerate_xcode_project; then
+if source "$REPO_ROOT/scripts/check-xcodegen-needed.sh" && should_regenerate_xcode_project; then
     pass "Detects missing .xcodeproj"
 else
     fail "Should detect missing .xcodeproj"
@@ -66,7 +70,7 @@ fi
 echo "Test 4: Returns true when project.yml doesn't exist"
 mkdir -p Olive.xcodeproj
 rm -f project.yml
-if source /tmp/olive-worktrees/issue-110/scripts/check-xcodegen-needed.sh && should_regenerate_xcode_project; then
+if source "$REPO_ROOT/scripts/check-xcodegen-needed.sh" && should_regenerate_xcode_project; then
     pass "Handles missing project.yml gracefully"
 else
     fail "Should handle missing project.yml"

--- a/scripts/tests/test-xcodegen-check.sh
+++ b/scripts/tests/test-xcodegen-check.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Test script for XcodeGen optimization logic
+# This tests the logic that determines whether XcodeGen needs to run
+
+set -e
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Test helper functions
+pass() {
+    echo -e "${GREEN}✓${NC} $1"
+    TEST_PASSED=$((TEST_PASSED + 1))
+}
+
+fail() {
+    echo -e "${RED}✗${NC} $1"
+    TEST_FAILED=$((TEST_FAILED + 1))
+}
+
+# Create a temporary test directory
+TEST_DIR=$(mktemp -d)
+cd "$TEST_DIR"
+
+echo "Running XcodeGen optimization tests..."
+echo "Test directory: $TEST_DIR"
+echo ""
+
+# Test 1: should_regenerate_xcode_project returns true when project.yml is newer
+echo "Test 1: Returns true when project.yml is newer than .xcodeproj"
+touch -t 202401010000 Olive.xcodeproj
+touch -t 202401020000 project.yml
+if source /tmp/olive-worktrees/issue-110/scripts/check-xcodegen-needed.sh && should_regenerate_xcode_project; then
+    pass "Detects project.yml is newer"
+else
+    fail "Should detect project.yml is newer"
+fi
+
+# Test 2: should_regenerate_xcode_project returns false when .xcodeproj is newer
+echo "Test 2: Returns false when .xcodeproj is newer than project.yml"
+touch -t 202401020000 Olive.xcodeproj
+touch -t 202401010000 project.yml
+if source /tmp/olive-worktrees/issue-110/scripts/check-xcodegen-needed.sh && ! should_regenerate_xcode_project; then
+    pass "Detects .xcodeproj is up to date"
+else
+    fail "Should detect .xcodeproj is up to date"
+fi
+
+# Test 3: should_regenerate_xcode_project returns true when .xcodeproj doesn't exist
+echo "Test 3: Returns true when .xcodeproj doesn't exist"
+rm -rf Olive.xcodeproj
+touch project.yml
+if source /tmp/olive-worktrees/issue-110/scripts/check-xcodegen-needed.sh && should_regenerate_xcode_project; then
+    pass "Detects missing .xcodeproj"
+else
+    fail "Should detect missing .xcodeproj"
+fi
+
+# Test 4: should_regenerate_xcode_project returns true when project.yml doesn't exist
+echo "Test 4: Returns true when project.yml doesn't exist"
+mkdir -p Olive.xcodeproj
+rm -f project.yml
+if source /tmp/olive-worktrees/issue-110/scripts/check-xcodegen-needed.sh && should_regenerate_xcode_project; then
+    pass "Handles missing project.yml gracefully"
+else
+    fail "Should handle missing project.yml"
+fi
+
+# Cleanup
+cd /
+rm -rf "$TEST_DIR"
+
+# Summary
+echo ""
+echo "=========================="
+echo "Test Results:"
+echo "  Passed: $TEST_PASSED"
+echo "  Failed: $TEST_FAILED"
+echo "=========================="
+
+if [ $TEST_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed!${NC}"
+    exit 1
+fi

--- a/scripts/tests/test-xcodegen-check.sh
+++ b/scripts/tests/test-xcodegen-check.sh
@@ -33,7 +33,8 @@ echo ""
 
 # Test 1: should_regenerate_xcode_project returns true when project.yml is newer
 echo "Test 1: Returns true when project.yml is newer than .xcodeproj"
-touch -t 202401010000 Olive.xcodeproj
+mkdir -p Olive.xcodeproj
+touch -t 202401010000 Olive.xcodeproj/project.pbxproj
 touch -t 202401020000 project.yml
 if source /tmp/olive-worktrees/issue-110/scripts/check-xcodegen-needed.sh && should_regenerate_xcode_project; then
     pass "Detects project.yml is newer"
@@ -43,7 +44,7 @@ fi
 
 # Test 2: should_regenerate_xcode_project returns false when .xcodeproj is newer
 echo "Test 2: Returns false when .xcodeproj is newer than project.yml"
-touch -t 202401020000 Olive.xcodeproj
+touch -t 202401020000 Olive.xcodeproj/project.pbxproj
 touch -t 202401010000 project.yml
 if source /tmp/olive-worktrees/issue-110/scripts/check-xcodegen-needed.sh && ! should_regenerate_xcode_project; then
     pass "Detects .xcodeproj is up to date"

--- a/scripts/tests/test-xcodegen-check.sh
+++ b/scripts/tests/test-xcodegen-check.sh
@@ -48,6 +48,8 @@ fi
 
 # Test 2: should_regenerate_xcode_project returns false when .xcodeproj is newer
 echo "Test 2: Returns false when .xcodeproj is newer than project.yml"
+rm -rf Olive.xcodeproj
+mkdir -p Olive.xcodeproj
 touch -t 202401020000 Olive.xcodeproj/project.pbxproj
 touch -t 202401010000 project.yml
 if source "$REPO_ROOT/scripts/check-xcodegen-needed.sh" && ! should_regenerate_xcode_project; then
@@ -74,6 +76,57 @@ if source "$REPO_ROOT/scripts/check-xcodegen-needed.sh" && should_regenerate_xco
     pass "Handles missing project.yml gracefully"
 else
     fail "Should handle missing project.yml"
+fi
+
+# Test 5: Hash validation - matching hash returns false (no regeneration needed)
+echo "Test 5: Returns false when hash matches stored hash"
+rm -rf Olive.xcodeproj
+mkdir -p Olive.xcodeproj
+echo "test content" > project.yml
+touch -t 202401020000 Olive.xcodeproj/project.pbxproj
+touch -t 202401010000 project.yml
+# Generate and store the hash
+HASH=$(shasum -a 256 project.yml | awk '{print $1}')
+echo "$HASH" > Olive.xcodeproj/.project_yml_hash
+if source "$REPO_ROOT/scripts/check-xcodegen-needed.sh" && ! should_regenerate_xcode_project; then
+    pass "Detects matching hash - no regeneration needed"
+else
+    fail "Should detect matching hash and skip regeneration"
+fi
+
+# Test 6: Hash validation - mismatched hash returns true (regeneration needed)
+echo "Test 6: Returns true when hash doesn't match stored hash"
+rm -rf Olive.xcodeproj
+mkdir -p Olive.xcodeproj
+echo "test content" > project.yml
+touch Olive.xcodeproj/project.pbxproj
+# Store a different hash
+echo "wrong_hash_value_12345" > Olive.xcodeproj/.project_yml_hash
+if source "$REPO_ROOT/scripts/check-xcodegen-needed.sh" && should_regenerate_xcode_project; then
+    pass "Detects mismatched hash - regeneration needed"
+else
+    fail "Should detect mismatched hash and require regeneration"
+fi
+
+# Test 7: Hash validation - missing hash file falls back to timestamp check
+echo "Test 7: Falls back to timestamp check when hash file is missing"
+rm -rf Olive.xcodeproj
+mkdir -p Olive.xcodeproj
+echo "test content" > project.yml
+touch -t 202401020000 Olive.xcodeproj/project.pbxproj
+touch -t 202401010000 project.yml
+# No hash file exists
+if source "$REPO_ROOT/scripts/check-xcodegen-needed.sh" && ! should_regenerate_xcode_project; then
+    pass "Uses timestamp check when hash missing - creates hash file"
+else
+    fail "Should fall back to timestamp check and create hash file"
+fi
+
+# Verify hash file was created
+if [ -f Olive.xcodeproj/.project_yml_hash ]; then
+    pass "Hash file created for future validation"
+else
+    fail "Should create hash file when missing"
 fi
 
 # Cleanup


### PR DESCRIPTION
## Summary
Optimizes the CI workflow to avoid unnecessary XcodeGen installations and regenerations.

### Changes
- Cache XcodeGen binary installation to avoid reinstalling on every CI run
- Cache generated Xcode project based on project.yml hash  
- Only regenerate Xcode project when project.yml changes
- Add helper script (`scripts/check-xcodegen-needed.sh`) to validate if regeneration is needed

### Benefits
- Faster CI runs when project.yml hasn't changed
- Reduced network usage (no repeated XcodeGen downloads)
- Reduced build time (skip unnecessary project regeneration)

### Implementation Details
- Use `actions/cache@v4` for both XcodeGen binary and Xcode project
- Cache keys based on `hashFiles('project.yml')` for automatic invalidation when config changes
- Conditional steps using `cache-hit` output to skip unnecessary work
- Validation step ensures cached projects are still up-to-date

### TDD Approach
Following strict TDD methodology:
1. ✅ Test commit: `test: add CI workflow optimization tests (TDD)`
2. ✅ Implementation commit: `feat: optimize CI workflow to skip XcodeGen when not needed`
3. ✅ All tests passing

### Test Coverage
- Tests for XcodeGen check logic (file timestamp comparison)
- Tests for CI workflow caching configuration
- Tests for conditional XcodeGen execution
- Tests verify cache keys include project.yml hash

Fixes #110