### PR TITLE
Fix missing translations in localization catalog (Issue #153)

### DIFF
--- a/CallTranscription/Resources/Localizable.xcstrings
+++ b/CallTranscription/Resources/Localizable.xcstrings
@@ -1,8723 +1,9473 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "•" : {
-      "comment" : "Bullet point character",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "•"
+  "sourceLanguage": "en",
+  "strings": {
+    "•": {
+      "comment": "Bullet point character",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "•"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "•"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "•"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "•"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "•"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "•"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "•"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "•"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "•"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "•"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "•"
           }
         }
       }
     },
-    "config.validation.cannotCreateDirectory" : {
-      "comment" : "Cannot create directory error message (with %@ placeholders for path and error)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verzeichnis kann nicht erstellt werden: %@ - %@"
+    "config.validation.cannotCreateDirectory": {
+      "comment": "Cannot create directory error message (with %@ placeholders for path and error)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verzeichnis kann nicht erstellt werden: %@ - %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cannot create directory: %@ - %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot create directory: %@ - %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede crear el directorio: %@ - %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede crear el directorio: %@ - %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de créer le répertoire : %@ - %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de créer le répertoire : %@ - %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ディレクトリを作成できません：%@ - %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディレクトリを作成できません：%@ - %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法创建目录：%@ - %@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法创建目录：%@ - %@"
           }
         }
       }
     },
-    "config.validation.notDirectory" : {
-      "comment" : "Not a directory error message (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pfad existiert, ist aber kein Verzeichnis: %@"
+    "config.validation.notDirectory": {
+      "comment": "Not a directory error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pfad existiert, ist aber kein Verzeichnis: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Path exists but is not a directory: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path exists but is not a directory: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La ruta existe pero no es un directorio: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ruta existe pero no es un directorio: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le chemin existe mais n'est pas un répertoire : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le chemin existe mais n'est pas un répertoire : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パスは存在しますがディレクトリではありません：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パスは存在しますがディレクトリではありません：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "路径存在但不是目录：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路径存在但不是目录：%@"
           }
         }
       }
     },
-    "config.validation.notWritable" : {
-      "comment" : "Directory not writable error message (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verzeichnis ist nicht beschreibbar: %@"
+    "config.validation.notWritable": {
+      "comment": "Directory not writable error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verzeichnis ist nicht beschreibbar: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Directory is not writable: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Directory is not writable: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El directorio no tiene permisos de escritura: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El directorio no tiene permisos de escritura: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le répertoire n'est pas accessible en écriture : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le répertoire n'est pas accessible en écriture : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ディレクトリに書き込み権限がありません：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディレクトリに書き込み権限がありません：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目录不可写入：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目录不可写入：%@"
           }
         }
       }
     },
-    "config.validation.pathTraversal" : {
-      "comment" : "Path traversal error message",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pfad enthält ungültige Durchlauf-Sequenzen"
+    "config.validation.pathTraversal": {
+      "comment": "Path traversal error message",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pfad enthält ungültige Durchlauf-Sequenzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Path contains invalid traversal sequences"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path contains invalid traversal sequences"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La ruta contiene secuencias de navegación no válidas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ruta contiene secuencias de navegación no válidas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le chemin contient des séquences de traversée non valides"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le chemin contient des séquences de traversée non valides"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パスに無効なトラバーサルシーケンスが含まれています"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パスに無効なトラバーサルシーケンスが含まれています"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "路径包含无效的遍历序列"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路径包含无效的遍历序列"
           }
         }
       }
     },
-    "config.validation.scriptIsDirectory" : {
-      "comment" : "Script is directory error message (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skriptpfad ist ein Verzeichnis, keine Datei: %@"
+    "config.validation.scriptIsDirectory": {
+      "comment": "Script is directory error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriptpfad ist ein Verzeichnis, keine Datei: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Script path is a directory, not a file: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Script path is a directory, not a file: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La ruta del script es un directorio, no un archivo: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ruta del script es un directorio, no un archivo: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le chemin du script est un répertoire, pas un fichier : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le chemin du script est un répertoire, pas un fichier : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトパスはファイルではなくディレクトリです：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトパスはファイルではなくディレクトリです：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脚本路径是目录而非文件：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "脚本路径是目录而非文件：%@"
           }
         }
       }
     },
-    "config.validation.scriptNotExecutable" : {
-      "comment" : "Script not executable error message (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skriptdatei ist nicht ausführbar: %@"
+    "config.validation.scriptNotExecutable": {
+      "comment": "Script not executable error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriptdatei ist nicht ausführbar: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Script file is not executable: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Script file is not executable: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El archivo de script no tiene permisos de ejecución: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El archivo de script no tiene permisos de ejecución: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le fichier de script n'est pas exécutable : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fichier de script n'est pas exécutable : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトファイルに実行権限がありません：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトファイルに実行権限がありません：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脚本文件不可执行：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "脚本文件不可执行：%@"
           }
         }
       }
     },
-    "config.validation.scriptNotFound" : {
-      "comment" : "Script not found error message (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skriptdatei existiert nicht: %@"
+    "config.validation.scriptNotFound": {
+      "comment": "Script not found error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriptdatei existiert nicht: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Script file does not exist: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Script file does not exist: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El archivo de script no existe: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El archivo de script no existe: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le fichier de script n'existe pas : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fichier de script n'existe pas : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトファイルが存在しません：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトファイルが存在しません：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脚本文件不存在：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "脚本文件不存在：%@"
           }
         }
       }
     },
-    "config.validation.systemDirectory" : {
-      "comment" : "System directory error message (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systemverzeichnisse können nicht verwendet werden: %@"
+    "config.validation.systemDirectory": {
+      "comment": "System directory error message (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemverzeichnisse können nicht verwendet werden: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cannot use system directories: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot use system directories: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pueden usar directorios del sistema: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pueden usar directorios del sistema: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d'utiliser les répertoires système : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'utiliser les répertoires système : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムディレクトリは使用できません：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムディレクトリは使用できません：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法使用系统目录：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法使用系统目录：%@"
           }
         }
       }
     },
-    "consentDialog.body.accessibility.label" : {
-      "comment" : "Body accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gesetzliche Anforderungen"
+    "consentDialog.body.accessibility.label": {
+      "comment": "Body accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesetzliche Anforderungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legal requirements"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legal requirements"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requisitos legales"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requisitos legales"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exigences légales"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exigences légales"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "法的要件"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "法的要件"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "法律要求"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "法律要求"
           }
         }
       }
     },
-    "consentDialog.bullet1" : {
-      "comment" : "First bullet point",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahmegesetze variieren erheblich je nach Rechtsordnung"
+    "consentDialog.bullet1": {
+      "comment": "First bullet point",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmegesetze variieren erheblich je nach Rechtsordnung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording laws vary significantly by jurisdiction"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording laws vary significantly by jurisdiction"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las leyes de grabación varían significativamente según la jurisdicción"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las leyes de grabación varían significativamente según la jurisdicción"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les lois sur l'enregistrement varient considérablement selon la juridiction"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les lois sur l'enregistrement varient considérablement selon la juridiction"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音に関する法律は管轄区域によって大きく異なります"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音に関する法律は管轄区域によって大きく異なります"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音法律因司法管辖区而有很大差异"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音法律因司法管辖区而有很大差异"
           }
         }
       }
     },
-    "consentDialog.bullet2" : {
-      "comment" : "Second bullet point",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einige Regionen erfordern nur die Zustimmung einer Partei (Einparteien-Zustimmungsstaaten)"
+    "consentDialog.bullet2": {
+      "comment": "Second bullet point",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einige Regionen erfordern nur die Zustimmung einer Partei (Einparteien-Zustimmungsstaaten)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Some regions require only one party's consent (one-party consent states)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some regions require only one party's consent (one-party consent states)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Algunas regiones solo requieren el consentimiento de una parte (estados de consentimiento unilateral)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algunas regiones solo requieren el consentimiento de una parte (estados de consentimiento unilateral)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certaines régions ne nécessitent que le consentement d'une partie (états à consentement unilatéral)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certaines régions ne nécessitent que le consentement d'une partie (états à consentement unilatéral)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一部の地域では一者のみの同意が必要です（一者同意州）"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一部の地域では一者のみの同意が必要です（一者同意州）"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "某些地区仅需一方同意（单方同意州）"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "某些地区仅需一方同意（单方同意州）"
           }
         }
       }
     },
-    "consentDialog.bullet3" : {
-      "comment" : "Third bullet point",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Andere Regionen erfordern die Zustimmung aller Parteien vor der Aufnahme (Zweiparteien- oder Allparteien-Zustimmung)"
+    "consentDialog.bullet3": {
+      "comment": "Third bullet point",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Andere Regionen erfordern die Zustimmung aller Parteien vor der Aufnahme (Zweiparteien- oder Allparteien-Zustimmung)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Other regions require all parties to consent before recording (two-party or all-party consent)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Other regions require all parties to consent before recording (two-party or all-party consent)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otras regiones requieren que todas las partes den su consentimiento antes de grabar (consentimiento bilateral o de todas las partes)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otras regiones requieren que todas las partes den su consentimiento antes de grabar (consentimiento bilateral o de todas las partes)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "D'autres régions exigent le consentement de toutes les parties avant l'enregistrement (consentement bilatéral ou multilatéral)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "D'autres régions exigent le consentement de toutes les parties avant l'enregistrement (consentement bilatéral ou multilatéral)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "他の地域では録音前に全員の同意が必要です（双方または全員同意）"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "他の地域では録音前に全員の同意が必要です（双方または全員同意）"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "其他地区需要所有各方在录音前同意（双方或全方同意）"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其他地区需要所有各方在录音前同意（双方或全方同意）"
           }
         }
       }
     },
-    "consentDialog.bullet4" : {
-      "comment" : "Fourth bullet point",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Internationale Gesetze unterscheiden sich erheblich zwischen Ländern"
+    "consentDialog.bullet4": {
+      "comment": "Fourth bullet point",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internationale Gesetze unterscheiden sich erheblich zwischen Ländern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "International laws differ dramatically across countries"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "International laws differ dramatically across countries"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las leyes internacionales difieren dramáticamente entre países"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las leyes internacionales difieren dramáticamente entre países"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les lois internationales diffèrent considérablement d'un pays à l'autre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les lois internationales diffèrent considérablement d'un pays à l'autre"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "国際法は国によって大きく異なります"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "国際法は国によって大きく異なります"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "国际法律在各国之间差异显著"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "国际法律在各国之间差异显著"
           }
         }
       }
     },
-    "consentDialog.button.quit" : {
-      "comment" : "Quit button label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beenden"
+    "consentDialog.button.quit": {
+      "comment": "Quit button label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beenden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quit"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quitter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "終了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
           }
         }
       }
     },
-    "consentDialog.button.understand" : {
-      "comment" : "I Understand button label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ich verstehe"
+    "consentDialog.button.understand": {
+      "comment": "I Understand button label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ich verstehe"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I Understand"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I Understand"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entiendo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entiendo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Je comprends"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Je comprends"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "理解しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "理解しました"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "我明白"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我明白"
           }
         }
       }
     },
-    "consentDialog.checkbox.accessibility.hint" : {
-      "comment" : "Checkbox accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn aktiviert, wird dieser Zustimmungsdialog bei zukünftigen Starts nicht mehr angezeigt"
+    "consentDialog.checkbox.accessibility.hint": {
+      "comment": "Checkbox accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn aktiviert, wird dieser Zustimmungsdialog bei zukünftigen Starts nicht mehr angezeigt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When checked, this consent dialog will not be shown again on future launches"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When checked, this consent dialog will not be shown again on future launches"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cuando esté marcado, este diálogo de consentimiento no se mostrará nuevamente en futuros inicios"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuando esté marcado, este diálogo de consentimiento no se mostrará nuevamente en futuros inicios"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lorsque coché, cette boîte de dialogue de consentement ne sera plus affichée lors des lancements futurs"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lorsque coché, cette boîte de dialogue de consentement ne sera plus affichée lors des lancements futurs"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "チェックすると、今後の起動時にこの同意ダイアログは表示されません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チェックすると、今後の起動時にこの同意ダイアログは表示されません"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选中后，此同意对话框将不会在未来启动时再次显示"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选中后，此同意对话框将不会在未来启动时再次显示"
           }
         }
       }
     },
-    "consentDialog.checkbox.accessibility.label" : {
-      "comment" : "Checkbox accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht erneut erinnern"
+    "consentDialog.checkbox.accessibility.label": {
+      "comment": "Checkbox accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht erneut erinnern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Do not remind me again"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do not remind me again"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No recordarme de nuevo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No recordarme de nuevo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ne plus me rappeler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne plus me rappeler"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今後表示しない"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今後表示しない"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不再提醒我"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不再提醒我"
           }
         }
       }
     },
-    "consentDialog.checkbox.label" : {
-      "comment" : "Do not remind checkbox label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht erneut erinnern"
+    "consentDialog.checkbox.label": {
+      "comment": "Do not remind checkbox label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht erneut erinnern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Do not remind me again"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do not remind me again"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No recordarme de nuevo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No recordarme de nuevo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ne plus me rappeler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne plus me rappeler"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今後表示しない"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今後表示しない"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不再提醒我"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不再提醒我"
           }
         }
       }
     },
-    "consentDialog.intro" : {
-      "comment" : "Consent dialog intro text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bevor Sie diese App zum Aufnehmen von Gesprächen verwenden, beachten Sie bitte:"
+    "consentDialog.intro": {
+      "comment": "Consent dialog intro text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bevor Sie diese App zum Aufnehmen von Gesprächen verwenden, beachten Sie bitte:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Before using this app to record conversations, please understand:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Before using this app to record conversations, please understand:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Antes de usar esta aplicación para grabar conversaciones, comprenda lo siguiente:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antes de usar esta aplicación para grabar conversaciones, comprenda lo siguiente:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avant d'utiliser cette application pour enregistrer des conversations, veuillez comprendre :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avant d'utiliser cette application pour enregistrer des conversations, veuillez comprendre :"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "この アプリを使用して会話を録音する前に、以下をご理解ください："
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この アプリを使用して会話を録音する前に、以下をご理解ください："
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在使用此应用程序录制对话之前，请理解以下内容："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在使用此应用程序录制对话之前，请理解以下内容："
           }
         }
       }
     },
-    "consentDialog.quit.accessibility.hint" : {
-      "comment" : "Quit accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beendet die Anwendung ohne Zustimmungsanforderungen zu akzeptieren. Tastenkombination: Escape"
+    "consentDialog.quit.accessibility.hint": {
+      "comment": "Quit accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beendet die Anwendung ohne Zustimmungsanforderungen zu akzeptieren. Tastenkombination: Escape"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quits the application without accepting consent requirements. Keyboard shortcut: Escape"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quits the application without accepting consent requirements. Keyboard shortcut: Escape"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sale de la aplicación sin aceptar los requisitos de consentimiento. Atajo de teclado: Escape"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sale de la aplicación sin aceptar los requisitos de consentimiento. Atajo de teclado: Escape"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quitte l'application sans accepter les exigences de consentement. Raccourci clavier : Échap"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitte l'application sans accepter les exigences de consentement. Raccourci clavier : Échap"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "同意要件を承認せずにアプリケーションを終了します。キーボードショートカット：Escape"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同意要件を承認せずにアプリケーションを終了します。キーボードショートカット：Escape"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出应用程序而不接受同意要求。键盘快捷键：Escape"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出应用程序而不接受同意要求。键盘快捷键：Escape"
           }
         }
       }
     },
-    "consentDialog.quit.accessibility.label" : {
-      "comment" : "Quit accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beenden"
+    "consentDialog.quit.accessibility.label": {
+      "comment": "Quit accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beenden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quit"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quitter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "終了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
           }
         }
       }
     },
-    "consentDialog.responsibility" : {
-      "comment" : "User responsibility text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sie sind allein dafür verantwortlich, die Einhaltung aller geltenden Gesetze in Ihrer Rechtsordnung sicherzustellen, bevor Sie ein Gespräch aufzeichnen."
+    "consentDialog.responsibility": {
+      "comment": "User responsibility text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie sind allein dafür verantwortlich, die Einhaltung aller geltenden Gesetze in Ihrer Rechtsordnung sicherzustellen, bevor Sie ein Gespräch aufzeichnen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You are solely responsible for ensuring compliance with all applicable laws in your jurisdiction before recording any conversation."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You are solely responsible for ensuring compliance with all applicable laws in your jurisdiction before recording any conversation."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usted es el único responsable de garantizar el cumplimiento de todas las leyes aplicables en su jurisdicción antes de grabar cualquier conversación."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usted es el único responsable de garantizar el cumplimiento de todas las leyes aplicables en su jurisdicción antes de grabar cualquier conversación."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous êtes seul responsable de vous assurer de la conformité avec toutes les lois applicables dans votre juridiction avant d'enregistrer toute conversation."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous êtes seul responsable de vous assurer de la conformité avec toutes les lois applicables dans votre juridiction avant d'enregistrer toute conversation."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "会話を録音する前に、管轄区域の適用法令すべてを遵守することは、お客様の単独の責任です。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "会話を録音する前に、管轄区域の適用法令すべてを遵守することは、お客様の単独の責任です。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在录制任何对话之前，您有唯一责任确保遵守您所在司法管辖区的所有适用法律。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在录制任何对话之前，您有唯一责任确保遵守您所在司法管辖区的所有适用法律。"
           }
         }
       }
     },
-    "consentDialog.title" : {
-      "comment" : "Consent dialog title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wichtig: Zustimmungsanforderungen für Aufnahmen"
+    "consentDialog.title": {
+      "comment": "Consent dialog title",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wichtig: Zustimmungsanforderungen für Aufnahmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Important: Recording Consent Requirements"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Important: Recording Consent Requirements"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importante: Requisitos de consentimiento para grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importante: Requisitos de consentimiento para grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Important : Exigences de consentement pour l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Important : Exigences de consentement pour l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重要：録音の同意要件"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重要：録音の同意要件"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重要：录音同意要求"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重要：录音同意要求"
           }
         }
       }
     },
-    "consentDialog.title.accessibility.label" : {
-      "comment" : "Title accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wichtig: Zustimmungsanforderungen für Aufnahmen"
+    "consentDialog.title.accessibility.label": {
+      "comment": "Title accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wichtig: Zustimmungsanforderungen für Aufnahmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Important: Recording Consent Requirements"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Important: Recording Consent Requirements"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Importante: Requisitos de consentimiento para grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importante: Requisitos de consentimiento para grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Important : Exigences de consentement pour l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Important : Exigences de consentement pour l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重要：録音の同意要件"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重要：録音の同意要件"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重要：录音同意要求"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重要：录音同意要求"
           }
         }
       }
     },
-    "consentDialog.understand.accessibility.hint" : {
-      "comment" : "I Understand accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Akzeptiert die Zustimmungsanforderungen und schließt diesen Dialog. Tastenkombination: Eingabetaste"
+    "consentDialog.understand.accessibility.hint": {
+      "comment": "I Understand accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akzeptiert die Zustimmungsanforderungen und schließt diesen Dialog. Tastenkombination: Eingabetaste"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acknowledges consent requirements and dismisses this dialog. Keyboard shortcut: Return"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acknowledges consent requirements and dismisses this dialog. Keyboard shortcut: Return"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acepta los requisitos de consentimiento y cierra este diálogo. Atajo de teclado: Retorno"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acepta los requisitos de consentimiento y cierra este diálogo. Atajo de teclado: Retorno"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accepte les exigences de consentement et ferme cette boîte de dialogue. Raccourci clavier : Entrée"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accepte les exigences de consentement et ferme cette boîte de dialogue. Raccourci clavier : Entrée"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "同意要件を承認し、このダイアログを閉じます。キーボードショートカット：Return"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同意要件を承認し、このダイアログを閉じます。キーボードショートカット：Return"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "确认同意要求并关闭此对话框。键盘快捷键：Return"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认同意要求并关闭此对话框。键盘快捷键：Return"
           }
         }
       }
     },
-    "consentDialog.understand.accessibility.label" : {
-      "comment" : "I Understand accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ich verstehe"
+    "consentDialog.understand.accessibility.label": {
+      "comment": "I Understand accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ich verstehe"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I Understand"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I Understand"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entiendo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entiendo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Je comprends"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Je comprends"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "理解しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "理解しました"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "我明白"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我明白"
           }
         }
       }
     },
-    "consentDialog.warning" : {
-      "comment" : "Legal warning text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Versäumnis, die ordnungsgemäße Zustimmung einzuholen, kann zu zivil- oder strafrechtlicher Haftung führen."
+    "consentDialog.warning": {
+      "comment": "Legal warning text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Versäumnis, die ordnungsgemäße Zustimmung einzuholen, kann zu zivil- oder strafrechtlicher Haftung führen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failure to obtain proper consent may result in civil or criminal liability."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failure to obtain proper consent may result in civil or criminal liability."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No obtener el consentimiento adecuado puede resultar en responsabilidad civil o penal."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No obtener el consentimiento adecuado puede resultar en responsabilidad civil o penal."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le non-respect de l'obtention du consentement approprié peut entraîner une responsabilité civile ou pénale."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le non-respect de l'obtention du consentement approprié peut entraîner une responsabilité civile ou pénale."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "適切な同意を得ないと、民事または刑事責任を負う可能性があります。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適切な同意を得ないと、民事または刑事責任を負う可能性があります。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未能获得适当同意可能导致民事或刑事责任。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未能获得适当同意可能导致民事或刑事责任。"
           }
         }
       }
     },
-    "error.audioFileAlreadyFinalized.description" : {
-      "comment" : "Audio file already finalized error description",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audiodatei wurde bereits abgeschlossen"
+    "error.audioFileAlreadyFinalized.description": {
+      "comment": "Audio file already finalized error description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiodatei wurde bereits abgeschlossen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio file has already been finalized"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio file has already been finalized"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El archivo de audio ya ha sido finalizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El archivo de audio ya ha sido finalizado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le fichier audio a déjà été finalisé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fichier audio a déjà été finalisé"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音声ファイルは既に確定されています"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声ファイルは既に確定されています"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音频文件已完成"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频文件已完成"
           }
         }
       }
     },
-    "error.audioFileAlreadyFinalized.failureReason" : {
-      "comment" : "Audio file already finalized failure reason",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es wurde versucht, in eine bereits abgeschlossene Audiodatei zu schreiben"
+    "error.audioFileAlreadyFinalized.failureReason": {
+      "comment": "Audio file already finalized failure reason",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wurde versucht, in eine bereits abgeschlossene Audiodatei zu schreiben"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attempted to write to an audio file that has already been finalized"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attempted to write to an audio file that has already been finalized"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se intentó escribir en un archivo de audio que ya ha sido finalizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se intentó escribir en un archivo de audio que ya ha sido finalizado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tentative d'écriture dans un fichier audio déjà finalisé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tentative d'écriture dans un fichier audio déjà finalisé"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "既に確定された音声ファイルへの書き込みが試行されました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既に確定された音声ファイルへの書き込みが試行されました"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "尝试写入已完成的音频文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尝试写入已完成的音频文件"
           }
         }
       }
     },
-    "error.audioFileAlreadyFinalized.recoverySuggestion" : {
-      "comment" : "Audio file already finalized recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellen Sie eine neue Aufnahme, anstatt zu versuchen, zu einer abgeschlossenen Datei hinzuzufügen"
+    "error.audioFileAlreadyFinalized.recoverySuggestion": {
+      "comment": "Audio file already finalized recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen Sie eine neue Aufnahme, anstatt zu versuchen, zu einer abgeschlossenen Datei hinzuzufügen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create a new recording instead of trying to append to a finalized file"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create a new recording instead of trying to append to a finalized file"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cree una nueva grabación en lugar de intentar agregar a un archivo finalizado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cree una nueva grabación en lugar de intentar agregar a un archivo finalizado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créez un nouvel enregistrement au lieu d'essayer d'ajouter à un fichier finalisé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créez un nouvel enregistrement au lieu d'essayer d'ajouter à un fichier finalisé"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "確定されたファイルに追加しようとするのではなく、新しい録音を作成してください"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確定されたファイルに追加しようとするのではなく、新しい録音を作成してください"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建新录音而不是尝试追加到已完成的文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建新录音而不是尝试追加到已完成的文件"
           }
         }
       }
     },
-    "error.audioProcessingFailed.description" : {
-      "comment" : "Audio processing failed error description (with %@ placeholder for reason)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audioverarbeitung fehlgeschlagen: %@"
+    "error.audioProcessingFailed.description": {
+      "comment": "Audio processing failed error description (with %@ placeholder for reason)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioverarbeitung fehlgeschlagen: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio processing failed: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio processing failed: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error en el procesamiento de audio: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error en el procesamiento de audio: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec du traitement audio : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du traitement audio : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーディオ処理に失敗しました：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オーディオ処理に失敗しました：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音频处理失败：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频处理失败：%@"
           }
         }
       }
     },
-    "error.audioProcessingFailed.failureReason" : {
-      "comment" : "Audio processing failed failure reason (with %@ placeholder for reason)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bei der Audioverarbeitung ist ein Fehler aufgetreten: %@"
+    "error.audioProcessingFailed.failureReason": {
+      "comment": "Audio processing failed failure reason (with %@ placeholder for reason)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei der Audioverarbeitung ist ein Fehler aufgetreten: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio processing encountered an error: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio processing encountered an error: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El procesamiento de audio encontró un error: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El procesamiento de audio encontró un error: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le traitement audio a rencontré une erreur : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le traitement audio a rencontré une erreur : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーディオ処理でエラーが発生しました：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オーディオ処理でエラーが発生しました：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音频处理遇到错误：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频处理遇到错误：%@"
           }
         }
       }
     },
-    "error.audioProcessingFailed.recoverySuggestion" : {
-      "comment" : "Audio processing failed recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfen Sie die Audioformat-Kompatibilität und stellen Sie sicher, dass die Transkription läuft."
+    "error.audioProcessingFailed.recoverySuggestion": {
+      "comment": "Audio processing failed recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen Sie die Audioformat-Kompatibilität und stellen Sie sicher, dass die Transkription läuft."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check audio format compatibility and ensure transcription is running."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check audio format compatibility and ensure transcription is running."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifique la compatibilidad del formato de audio y asegúrese de que la transcripción esté en ejecución."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifique la compatibilidad del formato de audio y asegúrese de que la transcripción esté en ejecución."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifiez la compatibilité du format audio et assurez-vous que la transcription est en cours d'exécution."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifiez la compatibilité du format audio et assurez-vous que la transcription est en cours d'exécution."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーディオ形式の互換性を確認し、文字起こしが実行中であることを確認してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オーディオ形式の互換性を確認し、文字起こしが実行中であることを確認してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查音频格式兼容性并确保转录正在运行。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查音频格式兼容性并确保转录正在运行。"
           }
         }
       }
     },
-    "error.audioTapCreationFailed.description" : {
-      "comment" : "Audio tap creation failed error description (with %d placeholder for error code)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellung des Audio-Taps fehlgeschlagen (Fehlercode %d)."
+    "error.audioTapCreationFailed.description": {
+      "comment": "Audio tap creation failed error description (with %d placeholder for error code)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellung des Audio-Taps fehlgeschlagen (Fehlercode %d)."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to create audio tap (error %d)."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to create audio tap (error %d)."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error al crear conexión de audio (código de error %d)."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al crear conexión de audio (código de error %d)."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de la création du flux audio (code d'erreur %d)."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la création du flux audio (code d'erreur %d)."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オーディオタップの作成に失敗しました（エラーコード %d）。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オーディオタップの作成に失敗しました（エラーコード %d）。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建音频捕获失败（错误代码 %d）。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建音频捕获失败（错误代码 %d）。"
           }
         }
       }
     },
-    "error.audioTapCreationFailed.failureReason" : {
-      "comment" : "Audio tap creation failed failure reason (with %d placeholder for error code)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Core Audio hat beim Versuch, einen System-Audio-Tap zu erstellen, den Fehlercode %d zurückgegeben."
+    "error.audioTapCreationFailed.failureReason": {
+      "comment": "Audio tap creation failed failure reason (with %d placeholder for error code)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Core Audio hat beim Versuch, einen System-Audio-Tap zu erstellen, den Fehlercode %d zurückgegeben."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Core Audio returned error code %d when attempting to create a system audio tap."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Core Audio returned error code %d when attempting to create a system audio tap."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Core Audio devolvió el código de error %d al intentar crear una conexión de audio del sistema."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Core Audio devolvió el código de error %d al intentar crear una conexión de audio del sistema."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Core Audio a renvoyé le code d'erreur %d lors de la tentative de création d'un flux audio système."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Core Audio a renvoyé le code d'erreur %d lors de la tentative de création d'un flux audio système."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムオーディオタップの作成を試みた際、Core Audioがエラーコード %d を返しました。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムオーディオタップの作成を試みた際、Core Audioがエラーコード %d を返しました。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "尝试创建系统音频捕获时，Core Audio 返回错误代码 %d。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尝试创建系统音频捕获时，Core Audio 返回错误代码 %d。"
           }
         }
       }
     },
-    "error.audioTapCreationFailed.recoverySuggestion" : {
-      "comment" : "Audio tap creation failed recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System-Audioaufnahme ist nicht verfügbar. Versuchen Sie, die App neu zu starten, oder prüfen Sie auf System-Audiokonflikte."
+    "error.audioTapCreationFailed.recoverySuggestion": {
+      "comment": "Audio tap creation failed recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System-Audioaufnahme ist nicht verfügbar. Versuchen Sie, die App neu zu starten, oder prüfen Sie auf System-Audiokonflikte."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System audio capture is unavailable. Try restarting the app or check for system audio conflicts."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System audio capture is unavailable. Try restarting the app or check for system audio conflicts."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La captura de audio del sistema no está disponible. Intente reiniciar la aplicación o verifique si hay conflictos con el audio del sistema."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La captura de audio del sistema no está disponible. Intente reiniciar la aplicación o verifique si hay conflictos con el audio del sistema."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La capture audio système n'est pas disponible. Essayez de redémarrer l'application ou vérifiez les conflits audio système."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La capture audio système n'est pas disponible. Essayez de redémarrer l'application ou vérifiez les conflits audio système."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムオーディオキャプチャは利用できません。アプリを再起動するか、システムオーディオの競合を確認してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムオーディオキャプチャは利用できません。アプリを再起動するか、システムオーディオの競合を確認してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系统音频捕获不可用。尝试重启应用程序或检查系统音频冲突。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统音频捕获不可用。尝试重启应用程序或检查系统音频冲突。"
           }
         }
       }
     },
-    "error.bookmarkCreationFailed.description" : {
-      "comment" : "Error description when bookmark creation fails",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriffs-Lesezeichen für %@ konnte nicht erstellt werden: %@"
+    "error.bookmarkCreationFailed.description": {
+      "comment": "Error description when bookmark creation fails",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriffs-Lesezeichen für %@ konnte nicht erstellt werden: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to create access bookmark for %@: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to create access bookmark for %@: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo crear marcador de acceso para %@: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo crear marcador de acceso para %@: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de création du signet d'accès pour %@ : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de création du signet d'accès pour %@ : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ のアクセスブックマークを作成できませんでした: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ のアクセスブックマークを作成できませんでした: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法为 %@ 创建访问书签：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法为 %@ 创建访问书签：%@"
           }
         }
       }
     },
-    "error.bookmarkCreationFailed.failureReason" : {
-      "comment" : "Failure reason when bookmark creation fails",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dauerhafter Zugriff auf %@ kann nicht gesichert werden: %@"
+    "error.bookmarkCreationFailed.failureReason": {
+      "comment": "Failure reason when bookmark creation fails",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dauerhafter Zugriff auf %@ kann nicht gesichert werden: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to save persistent access to %@: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to save persistent access to %@: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede guardar el acceso persistente a %@: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede guardar el acceso persistente a %@: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d'enregistrer l'accès permanent à %@ : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'enregistrer l'accès permanent à %@ : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ への永続的なアクセスを保存できません: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ への永続的なアクセスを保存できません: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法保存对 %@ 的持久访问权限：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法保存对 %@ 的持久访问权限：%@"
           }
         }
       }
     },
-    "error.bookmarkCreationFailed.recoverySuggestion" : {
-      "comment" : "Recovery suggestion when bookmark creation fails",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie den Ordner erneut in den Einstellungen aus."
+    "error.bookmarkCreationFailed.recoverySuggestion": {
+      "comment": "Recovery suggestion when bookmark creation fails",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie den Ordner erneut in den Einstellungen aus."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try selecting the folder again in Settings."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try selecting the folder again in Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccione la carpeta nuevamente en Ajustes."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccione la carpeta nuevamente en Ajustes."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez à nouveau le dossier dans Réglages."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez à nouveau le dossier dans Réglages."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定でフォルダを再度選択してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定でフォルダを再度選択してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请在\"设置\"中重新选择文件夹。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请在\"设置\"中重新选择文件夹。"
           }
         }
       }
     },
-    "error.bookmarkResolutionFailed.description" : {
-      "comment" : "Error description when bookmark resolution fails",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriffs-Lesezeichen konnte nicht aufgelöst werden: %@"
+    "error.bookmarkResolutionFailed.description": {
+      "comment": "Error description when bookmark resolution fails",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriffs-Lesezeichen konnte nicht aufgelöst werden: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to resolve access bookmark: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to resolve access bookmark: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo resolver el marcador de acceso: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo resolver el marcador de acceso: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de résolution du signet d'accès : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de résolution du signet d'accès : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アクセスブックマークを解決できませんでした: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクセスブックマークを解決できませんでした: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法解析访问书签：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法解析访问书签：%@"
           }
         }
       }
     },
-    "error.bookmarkResolutionFailed.failureReason" : {
-      "comment" : "Failure reason when bookmark resolution fails",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auf den gespeicherten Ordner kann nicht zugegriffen werden: %@"
+    "error.bookmarkResolutionFailed.failureReason": {
+      "comment": "Failure reason when bookmark resolution fails",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf den gespeicherten Ordner kann nicht zugegriffen werden: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to access the saved folder: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to access the saved folder: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede acceder a la carpeta guardada: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede acceder a la carpeta guardada: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d'accéder au dossier enregistré : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'accéder au dossier enregistré : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存されたフォルダにアクセスできません: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存されたフォルダにアクセスできません: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法访问已保存的文件夹：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法访问已保存的文件夹：%@"
           }
         }
       }
     },
-    "error.bookmarkResolutionFailed.recoverySuggestion" : {
-      "comment" : "Recovery suggestion when bookmark resolution fails",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Ordner wurde möglicherweise verschoben oder gelöscht. Wählen Sie ihn erneut in den Einstellungen aus."
+    "error.bookmarkResolutionFailed.recoverySuggestion": {
+      "comment": "Recovery suggestion when bookmark resolution fails",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Ordner wurde möglicherweise verschoben oder gelöscht. Wählen Sie ihn erneut in den Einstellungen aus."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The folder may have been moved or deleted. Please select it again in Settings."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The folder may have been moved or deleted. Please select it again in Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es posible que la carpeta se haya movido o eliminado. Selecciónela nuevamente en Ajustes."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que la carpeta se haya movido o eliminado. Selecciónela nuevamente en Ajustes."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le dossier a peut-être été déplacé ou supprimé. Sélectionnez-le à nouveau dans Réglages."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le dossier a peut-être été déplacé ou supprimé. Sélectionnez-le à nouveau dans Réglages."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フォルダが移動または削除された可能性があります。設定で再度選択してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダが移動または削除された可能性があります。設定で再度選択してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文件夹可能已被移动或删除。请在\"设置\"中重新选择。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件夹可能已被移动或删除。请在\"设置\"中重新选择。"
           }
         }
       }
     },
-    "error.featureNotImplemented.description" : {
-      "comment" : "Feature not implemented error description (with %@ placeholder for feature name)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ist noch nicht implementiert."
+    "error.featureNotImplemented.description": {
+      "comment": "Feature not implemented error description (with %@ placeholder for feature name)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist noch nicht implementiert."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ is not yet implemented."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is not yet implemented."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ aún no está implementado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ aún no está implementado."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ n'est pas encore implémenté."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ n'est pas encore implémenté."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ はまだ実装されていません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はまだ実装されていません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 尚未实现。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 尚未实现。"
           }
         }
       }
     },
-    "error.featureNotImplemented.failureReason" : {
-      "comment" : "Feature not implemented failure reason (with %@ placeholder for feature name)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Funktionalität von %@ wurde noch nicht implementiert."
+    "error.featureNotImplemented.failureReason": {
+      "comment": "Feature not implemented failure reason (with %@ placeholder for feature name)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Funktionalität von %@ wurde noch nicht implementiert."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ functionality has not been implemented yet."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ functionality has not been implemented yet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La funcionalidad de %@ aún no ha sido implementada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La funcionalidad de %@ aún no ha sido implementada."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La fonctionnalité %@ n'a pas encore été implémentée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La fonctionnalité %@ n'a pas encore été implémentée."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ の機能はまだ実装されていません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の機能はまだ実装されていません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 功能尚未实现。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 功能尚未实现。"
           }
         }
       }
     },
-    "error.featureNotImplemented.recoverySuggestion" : {
-      "comment" : "Feature not implemented recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Funktion wird in einer zukünftigen Version verfügbar sein."
+    "error.featureNotImplemented.recoverySuggestion": {
+      "comment": "Feature not implemented recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Funktion wird in einer zukünftigen Version verfügbar sein."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This feature will be available in a future version."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This feature will be available in a future version."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta función estará disponible en una versión futura."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta función estará disponible en una versión futura."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cette fonctionnalité sera disponible dans une version future."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette fonctionnalité sera disponible dans une version future."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "この機能は将来のバージョンで利用可能になります。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この機能は将来のバージョンで利用可能になります。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此功能将在未来版本中提供。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此功能将在未来版本中提供。"
           }
         }
       }
     },
-    "error.invalidPath.description" : {
-      "comment" : "Invalid path error description (with %@ placeholders for path and reason)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ungültiger Pfad '%@': %@"
+    "error.invalidPath.description": {
+      "comment": "Invalid path error description (with %@ placeholders for path and reason)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger Pfad '%@': %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid path '%@': %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid path '%@': %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruta no válida '%@': %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta no válida '%@': %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chemin non valide '%@' : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin non valide '%@' : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無効なパス「%@」：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なパス「%@」：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无效路径 '%@'：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效路径 '%@'：%@"
           }
         }
       }
     },
-    "error.invalidPath.failureReason" : {
-      "comment" : "Invalid path failure reason (with %@ placeholders for path and reason)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Pfad '%@' ist nicht gültig: %@"
+    "error.invalidPath.failureReason": {
+      "comment": "Invalid path failure reason (with %@ placeholders for path and reason)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Pfad '%@' ist nicht gültig: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The path '%@' is not valid: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The path '%@' is not valid: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La ruta '%@' no es válida: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ruta '%@' no es válida: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le chemin '%@' n'est pas valide : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le chemin '%@' n'est pas valide : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パス「%@」は無効です：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パス「%@」は無効です：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "路径 '%@' 无效：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路径 '%@' 无效：%@"
           }
         }
       }
     },
-    "error.invalidPath.recoverySuggestion" : {
-      "comment" : "Invalid path recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geben Sie einen gültigen Dateipfad ohne Sonderzeichen oder verbotene Sequenzen an."
+    "error.invalidPath.recoverySuggestion": {
+      "comment": "Invalid path recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geben Sie einen gültigen Dateipfad ohne Sonderzeichen oder verbotene Sequenzen an."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Provide a valid file path without special characters or forbidden sequences."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provide a valid file path without special characters or forbidden sequences."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proporcione una ruta de archivo válida sin caracteres especiales o secuencias prohibidas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporcione una ruta de archivo válida sin caracteres especiales o secuencias prohibidas."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fournissez un chemin de fichier valide sans caractères spéciaux ni séquences interdites."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fournissez un chemin de fichier valide sans caractères spéciaux ni séquences interdites."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "特殊文字や禁止されたシーケンスを含まない有効なファイルパスを指定してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "特殊文字や禁止されたシーケンスを含まない有効なファイルパスを指定してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "提供不含特殊字符或禁止序列的有效文件路径。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供不含特殊字符或禁止序列的有效文件路径。"
           }
         }
       }
     },
-    "error.localeNotSupported.description" : {
-      "comment" : "Locale not supported error description (with %@ placeholder for locale)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spracherkennung ist nicht verfügbar für %@."
+    "error.localeNotSupported.description": {
+      "comment": "Locale not supported error description (with %@ placeholder for locale)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spracherkennung ist nicht verfügbar für %@."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speech recognition is not available for %@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech recognition is not available for %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El reconocimiento de voz no está disponible para %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El reconocimiento de voz no está disponible para %@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La reconnaissance vocale n'est pas disponible pour %@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La reconnaissance vocale n'est pas disponible pour %@."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ の音声認識は利用できません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の音声認識は利用できません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 不支持语音识别。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 不支持语音识别。"
           }
         }
       }
     },
-    "error.localeNotSupported.failureReason" : {
-      "comment" : "Locale not supported failure reason (with %@ placeholder for locale)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Locale %@ wird vom Spracherkennungsdienst nicht unterstützt."
+    "error.localeNotSupported.failureReason": {
+      "comment": "Locale not supported failure reason (with %@ placeholder for locale)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Locale %@ wird vom Spracherkennungsdienst nicht unterstützt."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The locale %@ is not supported by the speech recognition service."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The locale %@ is not supported by the speech recognition service."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El servicio de reconocimiento de voz no admite el idioma %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El servicio de reconocimiento de voz no admite el idioma %@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La locale %@ n'est pas prise en charge par le service de reconnaissance vocale."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La locale %@ n'est pas prise en charge par le service de reconnaissance vocale."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ロケール %@ は音声認識サービスでサポートされていません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ロケール %@ は音声認識サービスでサポートされていません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音识别服务不支持区域设置 %@。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音识别服务不支持区域设置 %@。"
           }
         }
       }
     },
-    "error.localeNotSupported.recoverySuggestion" : {
-      "comment" : "Locale not supported recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versuchen Sie, eine andere Sprache oder ein anderes Locale auszuwählen, das von der Spracherkennung unterstützt wird."
+    "error.localeNotSupported.recoverySuggestion": {
+      "comment": "Locale not supported recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versuchen Sie, eine andere Sprache oder ein anderes Locale auszuwählen, das von der Spracherkennung unterstützt wird."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try selecting a different language or locale that is supported by speech recognition."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try selecting a different language or locale that is supported by speech recognition."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intente seleccionar un idioma o región diferente que sea compatible con el reconocimiento de voz."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intente seleccionar un idioma o región diferente que sea compatible con el reconocimiento de voz."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Essayez de sélectionner une autre langue ou locale prise en charge par la reconnaissance vocale."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Essayez de sélectionner une autre langue ou locale prise en charge par la reconnaissance vocale."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音声認識でサポートされている別の言語またはロケールを選択してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声認識でサポートされている別の言語またはロケールを選択してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "尝试选择语音识别支持的其他语言或区域设置。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尝试选择语音识别支持的其他语言或区域设置。"
           }
         }
       }
     },
-    "error.microphonePermissionDenied.description" : {
-      "comment" : "Microphone permission denied error description",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofonzugriff ist erforderlich."
+    "error.microphonePermissionDenied.description": {
+      "comment": "Microphone permission denied error description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofonzugriff ist erforderlich."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Microphone access is required."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone access is required."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se requiere acceso al micrófono."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requiere acceso al micrófono."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'accès au microphone est requis."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'accès au microphone est requis."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "マイクへのアクセスが必要です。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マイクへのアクセスが必要です。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "需要麦克风访问权限。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要麦克风访问权限。"
           }
         }
       }
     },
-    "error.microphonePermissionDenied.failureReason" : {
-      "comment" : "Microphone permission denied failure reason",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die App hat keine Berechtigung, auf das Mikrofon zuzugreifen."
+    "error.microphonePermissionDenied.failureReason": {
+      "comment": "Microphone permission denied failure reason",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die App hat keine Berechtigung, auf das Mikrofon zuzugreifen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The app does not have permission to access the microphone."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The app does not have permission to access the microphone."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La aplicación no tiene permiso para acceder al micrófono."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La aplicación no tiene permiso para acceder al micrófono."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'application n'a pas la permission d'accéder au microphone."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'application n'a pas la permission d'accéder au microphone."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリにマイクへのアクセス許可がありません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリにマイクへのアクセス許可がありません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用程序没有访问麦克风的权限。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用程序没有访问麦克风的权限。"
           }
         }
       }
     },
-    "error.microphonePermissionDenied.recoverySuggestion" : {
-      "comment" : "Microphone permission denied recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktivieren Sie den Mikrofonzugriff in Systemeinstellungen > Datenschutz & Sicherheit > Mikrofon."
+    "error.microphonePermissionDenied.recoverySuggestion": {
+      "comment": "Microphone permission denied recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren Sie den Mikrofonzugriff in Systemeinstellungen > Datenschutz & Sicherheit > Mikrofon."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable microphone access in System Settings > Privacy & Security > Microphone."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable microphone access in System Settings > Privacy & Security > Microphone."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Habilite el acceso al micrófono en Configuración del Sistema > Privacidad y Seguridad > Micrófono."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Habilite el acceso al micrófono en Configuración del Sistema > Privacidad y Seguridad > Micrófono."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activez l'accès au microphone dans Réglages système > Confidentialité et sécurité > Microphone."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez l'accès au microphone dans Réglages système > Confidentialité et sécurité > Microphone."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システム設定 > プライバシーとセキュリティ > マイクでマイクアクセスを有効にしてください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム設定 > プライバシーとセキュリティ > マイクでマイクアクセスを有効にしてください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在系统设置 > 隐私与安全性 > 麦克风中启用麦克风访问。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在系统设置 > 隐私与安全性 > 麦克风中启用麦克风访问。"
           }
         }
       }
     },
-    "error.notPaused.description" : {
-      "comment" : "Not paused error description",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Aufnahme ist derzeit nicht pausiert."
+    "error.notPaused.description": {
+      "comment": "Not paused error description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Aufnahme ist derzeit nicht pausiert."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording is not currently paused."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording is not currently paused."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La grabación no está actualmente en pausa."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La grabación no está actualmente en pausa."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'enregistrement n'est pas actuellement en pause."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'enregistrement n'est pas actuellement en pause."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音は現在一時停止されていません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音は現在一時停止されていません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音当前未暂停。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音当前未暂停。"
           }
         }
       }
     },
-    "error.notPaused.failureReason" : {
-      "comment" : "Not paused failure reason",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fortsetzen nicht möglich, da die Aufnahme nicht pausiert ist."
+    "error.notPaused.failureReason": {
+      "comment": "Not paused failure reason",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortsetzen nicht möglich, da die Aufnahme nicht pausiert ist."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cannot resume because recording is not paused."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot resume because recording is not paused."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede reanudar porque la grabación no está en pausa."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede reanudar porque la grabación no está en pausa."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de reprendre car l'enregistrement n'est pas en pause."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de reprendre car l'enregistrement n'est pas en pause."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音が一時停止されていないため再開できません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音が一時停止されていないため再開できません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法恢复，因为录音未暂停。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法恢复，因为录音未暂停。"
           }
         }
       }
     },
-    "error.notPaused.recoverySuggestion" : {
-      "comment" : "Not paused recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausieren Sie die Aufnahme, bevor Sie versuchen, sie fortzusetzen."
+    "error.notPaused.recoverySuggestion": {
+      "comment": "Not paused recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausieren Sie die Aufnahme, bevor Sie versuchen, sie fortzusetzen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause the recording first before attempting to resume."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause the recording first before attempting to resume."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause la grabación antes de intentar reanudarla."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause la grabación antes de intentar reanudarla."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mettez l'enregistrement en pause avant d'essayer de le reprendre."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettez l'enregistrement en pause avant d'essayer de le reprendre."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再開を試みる前に録音を一時停止してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再開を試みる前に録音を一時停止してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在尝试恢复之前先暂停录音。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在尝试恢复之前先暂停录音。"
           }
         }
       }
     },
-    "error.notRecording.description" : {
-      "comment" : "Not recording error description",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Derzeit ist keine Aufnahmesitzung aktiv."
+    "error.notRecording.description": {
+      "comment": "Not recording error description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derzeit ist keine Aufnahmesitzung aktiv."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No recording session is currently active."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No recording session is currently active."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay ninguna sesión de grabación activa actualmente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay ninguna sesión de grabación activa actualmente."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune session d'enregistrement n'est actuellement active."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune session d'enregistrement n'est actuellement active."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在アクティブな録音セッションはありません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在アクティブな録音セッションはありません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当前没有活动的录音会话。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前没有活动的录音会话。"
           }
         }
       }
     },
-    "error.notRecording.failureReason" : {
-      "comment" : "Not recording failure reason",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme kann nicht gestoppt werden, da keine Aufnahmesitzung aktiv ist."
+    "error.notRecording.failureReason": {
+      "comment": "Not recording failure reason",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme kann nicht gestoppt werden, da keine Aufnahmesitzung aktiv ist."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cannot stop recording because no recording session is active."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot stop recording because no recording session is active."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede detener la grabación porque no hay ninguna sesión de grabación activa."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede detener la grabación porque no hay ninguna sesión de grabación activa."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d'arrêter l'enregistrement car aucune session d'enregistrement n'est active."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'arrêter l'enregistrement car aucune session d'enregistrement n'est active."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音セッションがアクティブでないため、録音を停止できません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音セッションがアクティブでないため、録音を停止できません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法停止录音，因为没有活动的录音会话。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法停止录音，因为没有活动的录音会话。"
           }
         }
       }
     },
-    "error.notRecording.recoverySuggestion" : {
-      "comment" : "Not recording recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starten Sie eine Aufnahmesitzung, bevor Sie versuchen, sie zu stoppen."
+    "error.notRecording.recoverySuggestion": {
+      "comment": "Not recording recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten Sie eine Aufnahmesitzung, bevor Sie versuchen, sie zu stoppen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start a recording session before attempting to stop it."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start a recording session before attempting to stop it."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicie una sesión de grabación antes de intentar detenerla."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicie una sesión de grabación antes de intentar detenerla."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Démarrez une session d'enregistrement avant d'essayer de l'arrêter."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrez une session d'enregistrement avant d'essayer de l'arrêter."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止を試みる前に録音セッションを開始してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止を試みる前に録音セッションを開始してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在尝试停止之前先启动录音会话。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在尝试停止之前先启动录音会话。"
           }
         }
       }
     },
-    "error.outputFolderCreationFailed.description" : {
-      "comment" : "Output folder creation failed error description (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellung des Ausgabeordners bei %@ fehlgeschlagen."
+    "error.outputFolderCreationFailed.description": {
+      "comment": "Output folder creation failed error description (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellung des Ausgabeordners bei %@ fehlgeschlagen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to create output folder at %@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to create output folder at %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error al crear la carpeta de salida en %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al crear la carpeta de salida en %@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de la création du dossier de sortie à %@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la création du dossier de sortie à %@."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ に出力フォルダを作成できませんでした。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ に出力フォルダを作成できませんでした。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 %@ 创建输出文件夹失败。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 %@ 创建输出文件夹失败。"
           }
         }
       }
     },
-    "error.outputFolderCreationFailed.failureReason" : {
-      "comment" : "Output folder creation failed failure reason (with %@ placeholder for path and %@ for error)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verzeichnis konnte nicht bei %@ erstellt werden: %@"
+    "error.outputFolderCreationFailed.failureReason": {
+      "comment": "Output folder creation failed failure reason (with %@ placeholder for path and %@ for error)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verzeichnis konnte nicht bei %@ erstellt werden: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could not create directory at %@: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not create directory at %@: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo crear el directorio en %@: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo crear el directorio en %@: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de créer le répertoire à %@ : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de créer le répertoire à %@ : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ にディレクトリを作成できませんでした：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ にディレクトリを作成できませんでした：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法在 %@ 创建目录：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法在 %@ 创建目录：%@"
           }
         }
       }
     },
-    "error.outputFolderCreationFailed.recoverySuggestion" : {
-      "comment" : "Output folder creation failed recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfen Sie die Ordnerberechtigungen und stellen Sie sicher, dass Sie Zugriff haben, um an diesem Ort Verzeichnisse zu erstellen."
+    "error.outputFolderCreationFailed.recoverySuggestion": {
+      "comment": "Output folder creation failed recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen Sie die Ordnerberechtigungen und stellen Sie sicher, dass Sie Zugriff haben, um an diesem Ort Verzeichnisse zu erstellen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check folder permissions and ensure you have access to create directories at this location."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check folder permissions and ensure you have access to create directories at this location."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifique los permisos de la carpeta y asegúrese de tener acceso para crear directorios en esta ubicación."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifique los permisos de la carpeta y asegúrese de tener acceso para crear directorios en esta ubicación."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifiez les permissions du dossier et assurez-vous d'avoir accès pour créer des répertoires à cet emplacement."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifiez les permissions du dossier et assurez-vous d'avoir accès pour créer des répertoires à cet emplacement."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フォルダの権限を確認し、この場所でディレクトリを作成するアクセス権があることを確認してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダの権限を確認し、この場所でディレクトリを作成するアクセス権があることを確認してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查文件夹权限并确保您有权在此位置创建目录。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查文件夹权限并确保您有权在此位置创建目录。"
           }
         }
       }
     },
-    "error.outputFolderNotWritable.description" : {
-      "comment" : "Output folder not writable error description (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schreiben in %@ nicht möglich."
+    "error.outputFolderNotWritable.description": {
+      "comment": "Output folder not writable error description (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schreiben in %@ nicht möglich."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cannot write to %@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot write to %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede escribir en %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede escribir en %@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d'écrire dans %@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'écrire dans %@."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ に書き込めません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ に書き込めません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法写入 %@。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法写入 %@。"
           }
         }
       }
     },
-    "error.outputFolderNotWritable.failureReason" : {
-      "comment" : "Output folder not writable failure reason (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Ausgabeordner bei %@ ist aufgrund von Berechtigungs- oder Pfadproblemen nicht beschreibbar."
+    "error.outputFolderNotWritable.failureReason": {
+      "comment": "Output folder not writable failure reason (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Ausgabeordner bei %@ ist aufgrund von Berechtigungs- oder Pfadproblemen nicht beschreibbar."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The output folder at %@ is not writable due to permissions or path issues."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The output folder at %@ is not writable due to permissions or path issues."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La carpeta de salida en %@ no tiene permisos de escritura debido a problemas de permisos o ruta."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La carpeta de salida en %@ no tiene permisos de escritura debido a problemas de permisos o ruta."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le dossier de sortie à %@ n'est pas accessible en écriture en raison de problèmes de permissions ou de chemin."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le dossier de sortie à %@ n'est pas accessible en écriture en raison de problèmes de permissions ou de chemin."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ の出力フォルダは、権限またはパスの問題により書き込みできません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の出力フォルダは、権限またはパスの問題により書き込みできません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 的输出文件夹由于权限或路径问题而不可写入。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的输出文件夹由于权限或路径问题而不可写入。"
           }
         }
       }
     },
-    "error.outputFolderNotWritable.recoverySuggestion" : {
-      "comment" : "Output folder not writable recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie einen anderen Ordner aus, für den Sie Schreibberechtigungen haben, z. B. Ihren Dokumente- oder Schreibtisch-Ordner."
+    "error.outputFolderNotWritable.recoverySuggestion": {
+      "comment": "Output folder not writable recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie einen anderen Ordner aus, für den Sie Schreibberechtigungen haben, z. B. Ihren Dokumente- oder Schreibtisch-Ordner."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select a different folder where you have write permissions, such as your Documents or Desktop folder."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a different folder where you have write permissions, such as your Documents or Desktop folder."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccione una carpeta diferente donde tenga permisos de escritura, como su carpeta de Documentos o Escritorio."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccione una carpeta diferente donde tenga permisos de escritura, como su carpeta de Documentos o Escritorio."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez un dossier différent où vous avez des permissions d'écriture, tel que votre dossier Documents ou Bureau."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez un dossier différent où vous avez des permissions d'écriture, tel que votre dossier Documents ou Bureau."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "書類フォルダやデスクトップフォルダなど、書き込み権限のある別のフォルダを選択してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "書類フォルダやデスクトップフォルダなど、書き込み権限のある別のフォルダを選択してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择您有写入权限的其他文件夹，例如文稿或桌面文件夹。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择您有写入权限的其他文件夹，例如文稿或桌面文件夹。"
           }
         }
       }
     },
-    "error.pathOutsideAllowedDirectories.description" : {
-      "comment" : "Path outside allowed directories error description (with %@ placeholders for path and directories)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pfad '%@' befindet sich außerhalb der zulässigen Verzeichnisse: %@"
+    "error.pathOutsideAllowedDirectories.description": {
+      "comment": "Path outside allowed directories error description (with %@ placeholders for path and directories)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pfad '%@' befindet sich außerhalb der zulässigen Verzeichnisse: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Path '%@' is outside allowed directories: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path '%@' is outside allowed directories: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La ruta '%@' está fuera de los directorios permitidos: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ruta '%@' está fuera de los directorios permitidos: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le chemin '%@' est en dehors des répertoires autorisés : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le chemin '%@' est en dehors des répertoires autorisés : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パス「%@」は許可されたディレクトリの外にあります：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パス「%@」は許可されたディレクトリの外にあります：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "路径 '%@' 在允许的目录之外：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路径 '%@' 在允许的目录之外：%@"
           }
         }
       }
     },
-    "error.pathOutsideAllowedDirectories.failureReason" : {
-      "comment" : "Path outside allowed directories failure reason (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Pfad '%@' befindet sich nicht innerhalb der zulässigen Basisverzeichnisse für diesen Vorgang."
+    "error.pathOutsideAllowedDirectories.failureReason": {
+      "comment": "Path outside allowed directories failure reason (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Pfad '%@' befindet sich nicht innerhalb der zulässigen Basisverzeichnisse für diesen Vorgang."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The path '%@' is not within any of the allowed base directories for this operation."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The path '%@' is not within any of the allowed base directories for this operation."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La ruta '%@' no está dentro de ninguno de los directorios base permitidos para esta operación."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ruta '%@' no está dentro de ninguno de los directorios base permitidos para esta operación."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le chemin '%@' ne se trouve dans aucun des répertoires de base autorisés pour cette opération."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le chemin '%@' ne se trouve dans aucun des répertoires de base autorisés pour cette opération."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パス「%@」はこの操作で許可されているベースディレクトリ内にありません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パス「%@」はこの操作で許可されているベースディレクトリ内にありません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "路径 '%@' 不在此操作允许的任何基础目录内。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路径 '%@' 不在此操作允许的任何基础目录内。"
           }
         }
       }
     },
-    "error.pathOutsideAllowedDirectories.recoverySuggestion" : {
-      "comment" : "Path outside allowed directories recovery suggestion (with %@ placeholder for directory list)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie einen Standort innerhalb eines dieser zulässigen Verzeichnisse:\n  - %@"
+    "error.pathOutsideAllowedDirectories.recoverySuggestion": {
+      "comment": "Path outside allowed directories recovery suggestion (with %@ placeholder for directory list)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie einen Standort innerhalb eines dieser zulässigen Verzeichnisse:\n  - %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose a location within one of these allowed directories:\n  - %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a location within one of these allowed directories:\n  - %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elija una ubicación dentro de uno de estos directorios permitidos:\n  - %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elija una ubicación dentro de uno de estos directorios permitidos:\n  - %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez un emplacement dans l'un de ces répertoires autorisés :\n  - %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez un emplacement dans l'un de ces répertoires autorisés :\n  - %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "以下の許可されたディレクトリ内の場所を選択してください：\n  - %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以下の許可されたディレクトリ内の場所を選択してください：\n  - %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择以下允许目录之一中的位置：\n  - %@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择以下允许目录之一中的位置：\n  - %@"
           }
         }
       }
     },
-    "error.pathTraversalDetected.description" : {
-      "comment" : "Path traversal attack detected error description (with %@ placeholders for path and reason)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Path-Traversal-Angriff in '%@' erkannt: %@"
+    "error.pathTraversalDetected.description": {
+      "comment": "Path traversal attack detected error description (with %@ placeholders for path and reason)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path-Traversal-Angriff in '%@' erkannt: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Path traversal attack detected in '%@': %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path traversal attack detected in '%@': %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se detectó un ataque de navegación de ruta en '%@': %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se detectó un ataque de navegación de ruta en '%@': %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attaque par traversée de chemin détectée dans '%@' : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attaque par traversée de chemin détectée dans '%@' : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「%@」でパストラバーサル攻撃が検出されました：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」でパストラバーサル攻撃が検出されました：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 '%@' 中检测到路径遍历攻击：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 '%@' 中检测到路径遍历攻击：%@"
           }
         }
       }
     },
-    "error.pathTraversalDetected.failureReason" : {
-      "comment" : "Path traversal attack detected failure reason (with %@ placeholders for path and reason)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Pfad '%@' enthält Path-Traversal-Sequenzen, die versuchen, auf Verzeichnisse außerhalb des zulässigen Bereichs zuzugreifen: %@"
+    "error.pathTraversalDetected.failureReason": {
+      "comment": "Path traversal attack detected failure reason (with %@ placeholders for path and reason)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Pfad '%@' enthält Path-Traversal-Sequenzen, die versuchen, auf Verzeichnisse außerhalb des zulässigen Bereichs zuzugreifen: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The path '%@' contains path traversal sequences that attempt to access directories outside the allowed scope: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The path '%@' contains path traversal sequences that attempt to access directories outside the allowed scope: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La ruta '%@' contiene secuencias de navegación de ruta que intentan acceder a directorios fuera del alcance permitido: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La ruta '%@' contiene secuencias de navegación de ruta que intentan acceder a directorios fuera del alcance permitido: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le chemin '%@' contient des séquences de traversée qui tentent d'accéder à des répertoires en dehors de la portée autorisée : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le chemin '%@' contient des séquences de traversée qui tentent d'accéder à des répertoires en dehors de la portée autorisée : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パス「%@」には、許可された範囲外のディレクトリにアクセスしようとするパストラバーサルシーケンスが含まれています：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パス「%@」には、許可された範囲外のディレクトリにアクセスしようとするパストラバーサルシーケンスが含まれています：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "路径 '%@' 包含试图访问允许范围外目录的路径遍历序列：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路径 '%@' 包含试图访问允许范围外目录的路径遍历序列：%@"
           }
         }
       }
     },
-    "error.pathTraversalDetected.recoverySuggestion" : {
-      "comment" : "Path traversal attack detected recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwenden Sie einen Pfad innerhalb der zulässigen Verzeichnisse ohne '..' oder andere Traversal-Sequenzen."
+    "error.pathTraversalDetected.recoverySuggestion": {
+      "comment": "Path traversal attack detected recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden Sie einen Pfad innerhalb der zulässigen Verzeichnisse ohne '..' oder andere Traversal-Sequenzen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use a path within the allowed directories without '..' or other traversal sequences."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use a path within the allowed directories without '..' or other traversal sequences."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use una ruta dentro de los directorios permitidos sin '..' u otras secuencias de navegación."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use una ruta dentro de los directorios permitidos sin '..' u otras secuencias de navegación."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisez un chemin dans les répertoires autorisés sans '..' ou autres séquences de traversée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisez un chemin dans les répertoires autorisés sans '..' ou autres séquences de traversée."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「..」や他のトラバーサルシーケンスを含まない、許可されたディレクトリ内のパスを使用してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「..」や他のトラバーサルシーケンスを含まない、許可されたディレクトリ内のパスを使用してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用允许目录内的路径，不包含 '..' 或其他遍历序列。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用允许目录内的路径，不包含 '..' 或其他遍历序列。"
           }
         }
       }
     },
-    "error.postRecordingScriptNotExecutable.description" : {
-      "comment" : "Post-recording script not executable error description (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach-Aufnahme-Skript bei %@ ist nicht ausführbar."
+    "error.postRecordingScriptNotExecutable.description": {
+      "comment": "Post-recording script not executable error description (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach-Aufnahme-Skript bei %@ ist nicht ausführbar."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Post-recording script at %@ is not executable."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Post-recording script at %@ is not executable."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El script posterior a la grabación en %@ no tiene permisos de ejecución."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El script posterior a la grabación en %@ no tiene permisos de ejecución."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le script post-enregistrement à %@ n'est pas exécutable."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le script post-enregistrement à %@ n'est pas exécutable."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ の録音後スクリプトに実行権限がありません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の録音後スクリプトに実行権限がありません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 的录音后脚本不可执行。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的录音后脚本不可执行。"
           }
         }
       }
     },
-    "error.postRecordingScriptNotExecutable.failureReason" : {
-      "comment" : "Post-recording script not executable failure reason",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Skriptdatei existiert, hat aber keine Ausführungsberechtigungen."
+    "error.postRecordingScriptNotExecutable.failureReason": {
+      "comment": "Post-recording script not executable failure reason",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Skriptdatei existiert, hat aber keine Ausführungsberechtigungen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The script file exists but does not have execute permissions."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The script file exists but does not have execute permissions."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El archivo de script existe pero no tiene permisos de ejecución."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El archivo de script existe pero no tiene permisos de ejecución."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le fichier de script existe mais n'a pas les permissions d'exécution."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fichier de script existe mais n'a pas les permissions d'exécution."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトファイルは存在しますが、実行権限がありません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトファイルは存在しますが、実行権限がありません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脚本文件存在但没有执行权限。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "脚本文件存在但没有执行权限。"
           }
         }
       }
     },
-    "error.postRecordingScriptNotExecutable.recoverySuggestion" : {
-      "comment" : "Post-recording script not executable recovery suggestion (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Machen Sie das Skript ausführbar, indem Sie ausführen: chmod +x '%@'"
+    "error.postRecordingScriptNotExecutable.recoverySuggestion": {
+      "comment": "Post-recording script not executable recovery suggestion (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Machen Sie das Skript ausführbar, indem Sie ausführen: chmod +x '%@'"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Make the script executable by running: chmod +x '%@'"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Make the script executable by running: chmod +x '%@'"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haga ejecutable el script ejecutando: chmod +x '%@'"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haga ejecutable el script ejecutando: chmod +x '%@'"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rendez le script exécutable en exécutant : chmod +x '%@'"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rendez le script exécutable en exécutant : chmod +x '%@'"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "次のコマンドを実行してスクリプトを実行可能にしてください：chmod +x '%@'"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次のコマンドを実行してスクリプトを実行可能にしてください：chmod +x '%@'"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通过运行以下命令使脚本可执行：chmod +x '%@'"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过运行以下命令使脚本可执行：chmod +x '%@'"
           }
         }
       }
     },
-    "error.postRecordingScriptNotFound.description" : {
-      "comment" : "Post-recording script not found error description (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach-Aufnahme-Skript nicht gefunden bei %@."
+    "error.postRecordingScriptNotFound.description": {
+      "comment": "Post-recording script not found error description (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach-Aufnahme-Skript nicht gefunden bei %@."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Post-recording script not found at %@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Post-recording script not found at %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Script posterior a la grabación no encontrado en %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Script posterior a la grabación no encontrado en %@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Script post-enregistrement introuvable à %@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Script post-enregistrement introuvable à %@."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ に録音後スクリプトが見つかりません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ に録音後スクリプトが見つかりません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 %@ 找不到录音后脚本。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 %@ 找不到录音后脚本。"
           }
         }
       }
     },
-    "error.postRecordingScriptNotFound.failureReason" : {
-      "comment" : "Post-recording script not found failure reason (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Skriptdatei konnte nicht im angegebenen Pfad gefunden werden: %@."
+    "error.postRecordingScriptNotFound.failureReason": {
+      "comment": "Post-recording script not found failure reason (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Skriptdatei konnte nicht im angegebenen Pfad gefunden werden: %@."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The script file could not be found at the specified path: %@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The script file could not be found at the specified path: %@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo encontrar el archivo de script en la ruta especificada: %@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo encontrar el archivo de script en la ruta especificada: %@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le fichier de script n'a pas pu être trouvé au chemin spécifié : %@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fichier de script n'a pas pu être trouvé au chemin spécifié : %@."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "指定されたパスにスクリプトファイルが見つかりませんでした：%@。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指定されたパスにスクリプトファイルが見つかりませんでした：%@。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在指定路径找不到脚本文件：%@。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在指定路径找不到脚本文件：%@。"
           }
         }
       }
     },
-    "error.postRecordingScriptNotFound.recoverySuggestion" : {
-      "comment" : "Post-recording script not found recovery suggestion (with %@ placeholder for path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfen Sie, ob der Skriptpfad '%@' korrekt ist und die Datei existiert."
+    "error.postRecordingScriptNotFound.recoverySuggestion": {
+      "comment": "Post-recording script not found recovery suggestion (with %@ placeholder for path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen Sie, ob der Skriptpfad '%@' korrekt ist und die Datei existiert."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check that the script path '%@' is correct and the file exists."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check that the script path '%@' is correct and the file exists."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifique que la ruta del script '%@' sea correcta y que el archivo exista."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifique que la ruta del script '%@' sea correcta y que el archivo exista."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifiez que le chemin du script '%@' est correct et que le fichier existe."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifiez que le chemin du script '%@' est correct et que le fichier existe."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトパス「%@」が正しく、ファイルが存在することを確認してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトパス「%@」が正しく、ファイルが存在することを確認してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查脚本路径 '%@' 是否正确且文件存在。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查脚本路径 '%@' 是否正确且文件存在。"
           }
         }
       }
     },
-    "error.postRecordingScriptTimeout.description" : {
-      "comment" : "Post-recording script timeout error description (with %.0f placeholder for seconds)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach-Aufnahme-Skript hat Timeout von %.0f Sekunden überschritten."
+    "error.postRecordingScriptTimeout.description": {
+      "comment": "Post-recording script timeout error description (with %.0f placeholder for seconds)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach-Aufnahme-Skript hat Timeout von %.0f Sekunden überschritten."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Post-recording script exceeded timeout of %.0f seconds."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Post-recording script exceeded timeout of %.0f seconds."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El script posterior a la grabación excedió el tiempo de espera de %.0f segundos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El script posterior a la grabación excedió el tiempo de espera de %.0f segundos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le script post-enregistrement a dépassé le délai d'attente de %.0f secondes."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le script post-enregistrement a dépassé le délai d'attente de %.0f secondes."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音後スクリプトが %.0f 秒のタイムアウトを超過しました。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音後スクリプトが %.0f 秒のタイムアウトを超過しました。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音后脚本超过 %.0f 秒的超时时间。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音后脚本超过 %.0f 秒的超时时间。"
           }
         }
       }
     },
-    "error.postRecordingScriptTimeout.failureReason" : {
-      "comment" : "Post-recording script timeout failure reason (with %.0f placeholder for seconds)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Skript wurde nicht innerhalb von %.0f Sekunden abgeschlossen."
+    "error.postRecordingScriptTimeout.failureReason": {
+      "comment": "Post-recording script timeout failure reason (with %.0f placeholder for seconds)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Skript wurde nicht innerhalb von %.0f Sekunden abgeschlossen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The script did not complete within %.0f seconds."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The script did not complete within %.0f seconds."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El script no se completó en %.0f segundos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El script no se completó en %.0f segundos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le script ne s'est pas terminé dans les %.0f secondes."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le script ne s'est pas terminé dans les %.0f secondes."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトが %.0f 秒以内に完了しませんでした。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトが %.0f 秒以内に完了しませんでした。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脚本未在 %.0f 秒内完成。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "脚本未在 %.0f 秒内完成。"
           }
         }
       }
     },
-    "error.postRecordingScriptTimeout.recoverySuggestion" : {
-      "comment" : "Post-recording script timeout recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stellen Sie sicher, dass Ihr Skript in angemessener Zeit abgeschlossen wird, oder erhöhen Sie die Timeout-Einstellung."
+    "error.postRecordingScriptTimeout.recoverySuggestion": {
+      "comment": "Post-recording script timeout recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stellen Sie sicher, dass Ihr Skript in angemessener Zeit abgeschlossen wird, oder erhöhen Sie die Timeout-Einstellung."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ensure your script completes in a reasonable time, or increase the timeout setting."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ensure your script completes in a reasonable time, or increase the timeout setting."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asegúrese de que su script se complete en un tiempo razonable, o aumente la configuración de tiempo de espera."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asegúrese de que su script se complete en un tiempo razonable, o aumente la configuración de tiempo de espera."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Assurez-vous que votre script se termine dans un délai raisonnable, ou augmentez le paramètre de délai d'attente."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assurez-vous que votre script se termine dans un délai raisonnable, ou augmentez le paramètre de délai d'attente."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトが妥当な時間内に完了することを確認するか、タイムアウト設定を増やしてください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトが妥当な時間内に完了することを確認するか、タイムアウト設定を増やしてください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "确保您的脚本在合理时间内完成，或增加超时设置。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确保您的脚本在合理时间内完成，或增加超时设置。"
           }
         }
       }
     },
-    "error.securityScopedAccessFailed.description" : {
-      "comment" : "Error description when security-scoped access fails",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriff auf Ordner fehlgeschlagen: %@"
+    "error.securityScopedAccessFailed.description": {
+      "comment": "Error description when security-scoped access fails",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriff auf Ordner fehlgeschlagen: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to access folder: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to access folder: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo acceder a la carpeta: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo acceder a la carpeta: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec d'accès au dossier : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec d'accès au dossier : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フォルダにアクセスできませんでした: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダにアクセスできませんでした: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "访问文件夹失败：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "访问文件夹失败：%@"
           }
         }
       }
     },
-    "error.securityScopedAccessFailed.failureReason" : {
-      "comment" : "Failure reason when security-scoped access fails",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriff auf sicherheitsbeschränkte Ressource kann nicht gestartet werden: %@"
+    "error.securityScopedAccessFailed.failureReason": {
+      "comment": "Failure reason when security-scoped access fails",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriff auf sicherheitsbeschränkte Ressource kann nicht gestartet werden: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unable to start accessing security-scoped resource: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to start accessing security-scoped resource: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede iniciar el acceso al recurso con ámbito de seguridad: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede iniciar el acceso al recurso con ámbito de seguridad: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de démarrer l'accès à la ressource avec portée de sécurité : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de démarrer l'accès à la ressource avec portée de sécurité : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セキュリティスコープ付きリソースへのアクセスを開始できません: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セキュリティスコープ付きリソースへのアクセスを開始できません: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法开始访问安全范围资源：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法开始访问安全范围资源：%@"
           }
         }
       }
     },
-    "error.securityScopedAccessFailed.recoverySuggestion" : {
-      "comment" : "Recovery suggestion when security-scoped access fails",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie den Ordner erneut in den Einstellungen aus, um Zugriff zu gewähren."
+    "error.securityScopedAccessFailed.recoverySuggestion": {
+      "comment": "Recovery suggestion when security-scoped access fails",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie den Ordner erneut in den Einstellungen aus, um Zugriff zu gewähren."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try selecting the folder again in Settings to grant access."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try selecting the folder again in Settings to grant access."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccione la carpeta nuevamente en Ajustes para otorgar acceso."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccione la carpeta nuevamente en Ajustes para otorgar acceso."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez à nouveau le dossier dans Réglages pour accorder l'accès."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez à nouveau le dossier dans Réglages pour accorder l'accès."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定でフォルダを再度選択してアクセス権を付与してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定でフォルダを再度選択してアクセス権を付与してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请在\"设置\"中重新选择文件夹以授予访问权限。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请在\"设置\"中重新选择文件夹以授予访问权限。"
           }
         }
       }
     },
-    "error.speechRecognitionUnavailable.description" : {
-      "comment" : "Speech recognition unavailable error description",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spracherkennung ist nicht verfügbar."
+    "error.speechRecognitionUnavailable.description": {
+      "comment": "Speech recognition unavailable error description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spracherkennung ist nicht verfügbar."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speech recognition is not available."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech recognition is not available."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El reconocimiento de voz no está disponible."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El reconocimiento de voz no está disponible."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La reconnaissance vocale n'est pas disponible."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La reconnaissance vocale n'est pas disponible."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音声認識は利用できません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声認識は利用できません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音识别不可用。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音识别不可用。"
           }
         }
       }
     },
-    "error.speechRecognitionUnavailable.failureReason" : {
-      "comment" : "Speech recognition unavailable failure reason",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Spracherkennungsdienst ist nicht verfügbar oder das Sprachmodell wurde nicht heruntergeladen."
+    "error.speechRecognitionUnavailable.failureReason": {
+      "comment": "Speech recognition unavailable failure reason",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Spracherkennungsdienst ist nicht verfügbar oder das Sprachmodell wurde nicht heruntergeladen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The speech recognition service is unavailable or the language model has not been downloaded."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The speech recognition service is unavailable or the language model has not been downloaded."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El servicio de reconocimiento de voz no está disponible o el modelo de idioma no se ha descargado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El servicio de reconocimiento de voz no está disponible o el modelo de idioma no se ha descargado."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le service de reconnaissance vocale n'est pas disponible ou le modèle de langue n'a pas été téléchargé."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le service de reconnaissance vocale n'est pas disponible ou le modèle de langue n'a pas été téléchargé."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音声認識サービスが利用できないか、言語モデルがダウンロードされていません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声認識サービスが利用できないか、言語モデルがダウンロードされていません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音识别服务不可用或语言模型尚未下载。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音识别服务不可用或语言模型尚未下载。"
           }
         }
       }
     },
-    "error.speechRecognitionUnavailable.recoverySuggestion" : {
-      "comment" : "Speech recognition unavailable recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfen Sie Ihre Internetverbindung, damit das Spracherkennungsmodell heruntergeladen werden kann, oder versuchen Sie es später erneut."
+    "error.speechRecognitionUnavailable.recoverySuggestion": {
+      "comment": "Speech recognition unavailable recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen Sie Ihre Internetverbindung, damit das Spracherkennungsmodell heruntergeladen werden kann, oder versuchen Sie es später erneut."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check your internet connection to allow the speech recognition model to download, or try again later."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check your internet connection to allow the speech recognition model to download, or try again later."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifique su conexión a Internet para permitir que el modelo de reconocimiento de voz se descargue, o inténtelo de nuevo más tarde."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifique su conexión a Internet para permitir que el modelo de reconocimiento de voz se descargue, o inténtelo de nuevo más tarde."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifiez votre connexion Internet pour permettre le téléchargement du modèle de reconnaissance vocale, ou réessayez plus tard."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifiez votre connexion Internet pour permettre le téléchargement du modèle de reconnaissance vocale, ou réessayez plus tard."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音声認識モデルのダウンロードを許可するためにインターネット接続を確認するか、後でもう一度お試しください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声認識モデルのダウンロードを許可するためにインターネット接続を確認するか、後でもう一度お試しください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查您的互联网连接以允许下载语音识别模型，或稍后再试。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查您的互联网连接以允许下载语音识别模型，或稍后再试。"
           }
         }
       }
     },
-    "error.symlinkAttackDetected.description" : {
-      "comment" : "Symlink attack detected error description (with %@ placeholders for path and resolved path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symlink-Angriff erkannt: '%@' löst sich zu '%@' auf, das sich außerhalb der zulässigen Verzeichnisse befindet"
+    "error.symlinkAttackDetected.description": {
+      "comment": "Symlink attack detected error description (with %@ placeholders for path and resolved path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symlink-Angriff erkannt: '%@' löst sich zu '%@' auf, das sich außerhalb der zulässigen Verzeichnisse befindet"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symlink attack detected: '%@' resolves to '%@' which is outside allowed directories"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symlink attack detected: '%@' resolves to '%@' which is outside allowed directories"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se detectó un ataque de enlace simbólico: '%@' se resuelve a '%@' que está fuera de los directorios permitidos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se detectó un ataque de enlace simbólico: '%@' se resuelve a '%@' que está fuera de los directorios permitidos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attaque par lien symbolique détectée : '%@' pointe vers '%@' qui est en dehors des répertoires autorisés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attaque par lien symbolique détectée : '%@' pointe vers '%@' qui est en dehors des répertoires autorisés"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シンボリックリンク攻撃が検出されました：「%@」は許可されたディレクトリの外にある「%@」を指しています"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シンボリックリンク攻撃が検出されました：「%@」は許可されたディレクトリの外にある「%@」を指しています"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检测到符号链接攻击：'%@' 解析为 '%@'，其位于允许目录之外"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测到符号链接攻击：'%@' 解析为 '%@'，其位于允许目录之外"
           }
         }
       }
     },
-    "error.symlinkAttackDetected.failureReason" : {
-      "comment" : "Symlink attack detected failure reason (with %@ placeholders for path and resolved path)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Symlink bei '%@' zeigt auf '%@', das sich außerhalb der zulässigen Verzeichnisse befindet, was möglicherweise auf einen Sicherheitsangriff hinweist."
+    "error.symlinkAttackDetected.failureReason": {
+      "comment": "Symlink attack detected failure reason (with %@ placeholders for path and resolved path)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Symlink bei '%@' zeigt auf '%@', das sich außerhalb der zulässigen Verzeichnisse befindet, was möglicherweise auf einen Sicherheitsangriff hinweist."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The symlink at '%@' points to '%@', which is outside the allowed directories, potentially indicating a security attack."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The symlink at '%@' points to '%@', which is outside the allowed directories, potentially indicating a security attack."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El enlace simbólico en '%@' apunta a '%@', que está fuera de los directorios permitidos, lo que podría indicar un ataque de seguridad."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El enlace simbólico en '%@' apunta a '%@', que está fuera de los directorios permitidos, lo que podría indicar un ataque de seguridad."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le lien symbolique à '%@' pointe vers '%@', qui est en dehors des répertoires autorisés, indiquant potentiellement une attaque de sécurité."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le lien symbolique à '%@' pointe vers '%@', qui est en dehors des répertoires autorisés, indiquant potentiellement une attaque de sécurité."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「%@」のシンボリックリンクは、許可されたディレクトリの外にある「%@」を指しており、セキュリティ攻撃の可能性があります。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」のシンボリックリンクは、許可されたディレクトリの外にある「%@」を指しており、セキュリティ攻撃の可能性があります。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "'%@' 的符号链接指向 '%@'，其位于允许目录之外，可能表明存在安全攻击。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "'%@' 的符号链接指向 '%@'，其位于允许目录之外，可能表明存在安全攻击。"
           }
         }
       }
     },
-    "error.symlinkAttackDetected.recoverySuggestion" : {
-      "comment" : "Symlink attack detected recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwenden Sie einen direkten Pfad oder stellen Sie sicher, dass Symlinks nur auf Orte innerhalb der zulässigen Verzeichnisse zeigen."
+    "error.symlinkAttackDetected.recoverySuggestion": {
+      "comment": "Symlink attack detected recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden Sie einen direkten Pfad oder stellen Sie sicher, dass Symlinks nur auf Orte innerhalb der zulässigen Verzeichnisse zeigen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use a direct path or ensure symlinks only point to locations within allowed directories."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use a direct path or ensure symlinks only point to locations within allowed directories."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use una ruta directa o asegúrese de que los enlaces simbólicos solo apunten a ubicaciones dentro de los directorios permitidos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use una ruta directa o asegúrese de que los enlaces simbólicos solo apunten a ubicaciones dentro de los directorios permitidos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisez un chemin direct ou assurez-vous que les liens symboliques pointent uniquement vers des emplacements dans les répertoires autorisés."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisez un chemin direct ou assurez-vous que les liens symboliques pointent uniquement vers des emplacements dans les répertoires autorisés."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "直接パスを使用するか、シンボリックリンクが許可されたディレクトリ内の場所のみを指していることを確認してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接パスを使用するか、シンボリックリンクが許可されたディレクトリ内の場所のみを指していることを確認してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用直接路径或确保符号链接仅指向允许目录内的位置。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用直接路径或确保符号链接仅指向允许目录内的位置。"
           }
         }
       }
     },
-    "error.transcriptAlreadyFinalized.description" : {
-      "comment" : "Transcript already finalized error description",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eine abgeschlossene Transkription kann nicht geändert werden."
+    "error.transcriptAlreadyFinalized.description": {
+      "comment": "Transcript already finalized error description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine abgeschlossene Transkription kann nicht geändert werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cannot modify a finalized transcript."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cannot modify a finalized transcript."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se puede modificar una transcripción finalizada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede modificar una transcripción finalizada."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de modifier une transcription finalisée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de modifier une transcription finalisée."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完成した文字起こしは変更できません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成した文字起こしは変更できません。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法修改已完成的转录。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法修改已完成的转录。"
           }
         }
       }
     },
-    "error.transcriptAlreadyFinalized.failureReason" : {
-      "comment" : "Transcript already finalized failure reason",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Transkriptionsdatei wurde abgeschlossen und kann nicht mehr geändert werden."
+    "error.transcriptAlreadyFinalized.failureReason": {
+      "comment": "Transcript already finalized failure reason",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Transkriptionsdatei wurde abgeschlossen und kann nicht mehr geändert werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The transcript file has been finalized and can no longer be modified."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The transcript file has been finalized and can no longer be modified."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El archivo de transcripción ha sido finalizado y ya no se puede modificar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El archivo de transcripción ha sido finalizado y ya no se puede modificar."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le fichier de transcription a été finalisé et ne peut plus être modifié."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fichier de transcription a été finalisé et ne peut plus être modifié."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文字起こしファイルは完成しており、変更できなくなりました。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字起こしファイルは完成しており、変更できなくなりました。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "转录文件已完成，无法再修改。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录文件已完成，无法再修改。"
           }
         }
       }
     },
-    "error.transcriptAlreadyFinalized.recoverySuggestion" : {
-      "comment" : "Transcript already finalized recovery suggestion",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellen Sie einen neuen Transkriptions-Writer, wenn Sie mehr Inhalt schreiben müssen."
+    "error.transcriptAlreadyFinalized.recoverySuggestion": {
+      "comment": "Transcript already finalized recovery suggestion",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen Sie einen neuen Transkriptions-Writer, wenn Sie mehr Inhalt schreiben müssen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create a new transcript writer if you need to write more content."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create a new transcript writer if you need to write more content."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cree un nuevo escritor de transcripción si necesita escribir más contenido."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cree un nuevo escritor de transcripción si necesita escribir más contenido."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créez un nouveau rédacteur de transcription si vous devez écrire plus de contenu."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créez un nouveau rédacteur de transcription si vous devez écrire plus de contenu."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "さらにコンテンツを書き込む必要がある場合は、新しいトランスクリプトライターを作成してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "さらにコンテンツを書き込む必要がある場合は、新しいトランスクリプトライターを作成してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果需要写入更多内容，请创建新的转录写入器。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果需要写入更多内容，请创建新的转录写入器。"
           }
         }
       }
     },
-    "intent.error.appNotAvailable" : {
-      "comment" : "App not available error description",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive ist nicht verfügbar"
+    "intent.error.appNotAvailable": {
+      "comment": "App not available error description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive ist nicht verfügbar"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive is not available"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive is not available"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive no está disponible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive no está disponible"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive n'est pas disponible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive n'est pas disponible"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive は利用できません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive は利用できません"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive 不可用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive 不可用"
           }
         }
       }
     },
-    "intent.error.configurationFailed" : {
-      "comment" : "Configuration failed error description (with %@ placeholder for reason)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguration fehlgeschlagen: %@"
+    "intent.error.configurationFailed": {
+      "comment": "Configuration failed error description (with %@ placeholder for reason)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguration fehlgeschlagen: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration failed: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration failed: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de configuración: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de configuración: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de la configuration : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la configuration : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定に失敗しました：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定に失敗しました：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "配置失败：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置失败：%@"
           }
         }
       }
     },
-    "intent.error.notRecording" : {
-      "comment" : "Not recording error description",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Derzeit ist keine Aufnahmesitzung aktiv"
+    "intent.error.notRecording": {
+      "comment": "Not recording error description",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derzeit ist keine Aufnahmesitzung aktiv"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No recording session is currently active"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No recording session is currently active"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay ninguna sesión de grabación activa actualmente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay ninguna sesión de grabación activa actualmente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune session d'enregistrement n'est actuellement active"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune session d'enregistrement n'est actuellement active"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在アクティブな録音セッションはありません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在アクティブな録音セッションはありません"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当前没有活动的录音会话"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前没有活动的录音会话"
           }
         }
       }
     },
-    "intent.error.recordingFailed" : {
-      "comment" : "Recording failed error description (with %@ placeholder for reason)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme fehlgeschlagen: %@"
+    "intent.error.recordingFailed": {
+      "comment": "Recording failed error description (with %@ placeholder for reason)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme fehlgeschlagen: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording failed: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording failed: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error en la grabación: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error en la grabación: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de l'enregistrement : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de l'enregistrement : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音に失敗しました：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音に失敗しました：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音失败：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音失败：%@"
           }
         }
       }
     },
-    "intent.recording.defaultTitle" : {
-      "comment" : "Default recording title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbenannte Aufnahme"
+    "intent.recording.defaultTitle": {
+      "comment": "Default recording title",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbenannte Aufnahme"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Untitled Recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Untitled Recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grabación sin título"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabación sin título"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrement sans titre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement sans titre"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無題の録音"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無題の録音"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无标题录音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无标题录音"
           }
         }
       }
     },
-    "intent.status.notRecording" : {
-      "comment" : "Not recording status message",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht aufnehmend"
+    "intent.status.notRecording": {
+      "comment": "Not recording status message",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht aufnehmend"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No grabando"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No grabando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pas d'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas d'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音していません"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音していません"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未录音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未录音"
           }
         }
       }
     },
-    "intent.status.recordingInProgress" : {
-      "comment" : "Recording in progress status message (with %@ placeholder for elapsed time)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme läuft: %@"
+    "intent.status.recordingInProgress": {
+      "comment": "Recording in progress status message (with %@ placeholder for elapsed time)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme läuft: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording in progress: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording in progress: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grabación en curso: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabación en curso: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrement en cours : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement en cours : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音中：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音中：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在录音：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在录音：%@"
           }
         }
       }
     },
-    "intent.status.recordingPaused" : {
-      "comment" : "Recording paused status message (with %@ placeholder for elapsed time)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme pausiert bei %@"
+    "intent.status.recordingPaused": {
+      "comment": "Recording paused status message (with %@ placeholder for elapsed time)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme pausiert bei %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording paused at %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording paused at %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grabación pausada en %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabación pausada en %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrement en pause à %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement en pause à %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ で一時停止中"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ で一時停止中"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音在 %@ 暂停"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音在 %@ 暂停"
           }
         }
       }
     },
-    "localization.test.placeholder" : {
-      "comment" : "Placeholder entry for initial String Catalog setup. Will be replaced with actual localized strings in subsequent phases.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Platzhalter"
+    "localization.test.placeholder": {
+      "comment": "Placeholder entry for initial String Catalog setup. Will be replaced with actual localized strings in subsequent phases.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Platzhalter"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Placeholder"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Placeholder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Marcador de posición"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcador de posición"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Espace réservé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espace réservé"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プレースホルダー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレースホルダー"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "占位符"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "占位符"
           }
         }
       }
     },
-    "menubar.accessibility.pausedDuration.label" : {
-      "comment" : "Accessibility label for paused duration display",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause-Dauer"
+    "menubar.accessibility.pausedDuration.label": {
+      "comment": "Accessibility label for paused duration display",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause-Dauer"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paused duration"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paused duration"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duración de la pausa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duración de la pausa"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durée de la pause"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durée de la pause"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時停止時間"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一時停止時間"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暂停时长"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂停时长"
           }
         }
       }
     },
-    "menubar.accessibility.pauseRecording.hint" : {
-      "comment" : "Accessibility hint for pause recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausiert die aktuelle Aufnahme. Tastenkombination: Befehl Umschalt P"
+    "menubar.accessibility.pauseRecording.hint": {
+      "comment": "Accessibility hint for pause recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausiert die aktuelle Aufnahme. Tastenkombination: Befehl Umschalt P"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pauses the current recording. Keyboard shortcut: Command Shift P"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pauses the current recording. Keyboard shortcut: Command Shift P"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausa la grabación actual. Atajo de teclado: Comando Mayús P"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausa la grabación actual. Atajo de teclado: Comando Mayús P"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Met en pause l'enregistrement en cours. Raccourci clavier : Commande Maj P"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Met en pause l'enregistrement en cours. Raccourci clavier : Commande Maj P"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在の録音を一時停止します。キーボードショートカット：Command Shift P"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の録音を一時停止します。キーボードショートカット：Command Shift P"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暂停当前录音。键盘快捷键：Command Shift P"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂停当前录音。键盘快捷键：Command Shift P"
           }
         }
       }
     },
-    "menubar.accessibility.pauseRecording.label" : {
-      "comment" : "Accessibility label for pause recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme pausieren"
+    "menubar.accessibility.pauseRecording.label": {
+      "comment": "Accessibility label for pause recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme pausieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause Recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause Recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausar grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mettre en pause l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre en pause l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を一時停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を一時停止"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暂停录音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂停录音"
           }
         }
       }
     },
-    "menubar.accessibility.quit.hint" : {
-      "comment" : "Accessibility hint for quit button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beendet die Anwendung. Tastenkombination: Befehl Q"
+    "menubar.accessibility.quit.hint": {
+      "comment": "Accessibility hint for quit button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beendet die Anwendung. Tastenkombination: Befehl Q"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quits the application. Keyboard shortcut: Command Q"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quits the application. Keyboard shortcut: Command Q"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sale de la aplicación. Atajo de teclado: Comando Q"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sale de la aplicación. Atajo de teclado: Comando Q"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quitte l'application. Raccourci clavier : Commande Q"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitte l'application. Raccourci clavier : Commande Q"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリケーションを終了します。キーボードショートカット：Command Q"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションを終了します。キーボードショートカット：Command Q"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出应用程序。键盘快捷键：Command Q"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出应用程序。键盘快捷键：Command Q"
           }
         }
       }
     },
-    "menubar.accessibility.quit.label" : {
-      "comment" : "Accessibility label for quit button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beenden"
+    "menubar.accessibility.quit.label": {
+      "comment": "Accessibility label for quit button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beenden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quit"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quitter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "終了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
           }
         }
       }
     },
-    "menubar.accessibility.recordingDuration.label" : {
-      "comment" : "Accessibility label for recording duration display",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahmedauer"
+    "menubar.accessibility.recordingDuration.label": {
+      "comment": "Accessibility label for recording duration display",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmedauer"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording duration"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording duration"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duración de la grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duración de la grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durée de l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durée de l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音時間"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音時間"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音时长"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音时长"
           }
         }
       }
     },
-    "menubar.accessibility.resumeRecording.hint" : {
-      "comment" : "Accessibility hint for resume recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setzt die pausierte Aufnahme fort. Tastenkombination: Befehl Umschalt R"
+    "menubar.accessibility.resumeRecording.hint": {
+      "comment": "Accessibility hint for resume recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setzt die pausierte Aufnahme fort. Tastenkombination: Befehl Umschalt R"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resumes the paused recording. Keyboard shortcut: Command Shift R"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumes the paused recording. Keyboard shortcut: Command Shift R"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reanuda la grabación pausada. Atajo de teclado: Comando Mayús R"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanuda la grabación pausada. Atajo de teclado: Comando Mayús R"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reprend l'enregistrement en pause. Raccourci clavier : Commande Maj R"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprend l'enregistrement en pause. Raccourci clavier : Commande Maj R"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時停止中の録音を再開します。キーボードショートカット：Command Shift R"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一時停止中の録音を再開します。キーボードショートカット：Command Shift R"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复暂停的录音。键盘快捷键：Command Shift R"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复暂停的录音。键盘快捷键：Command Shift R"
           }
         }
       }
     },
-    "menubar.accessibility.resumeRecording.label" : {
-      "comment" : "Accessibility label for resume recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme fortsetzen"
+    "menubar.accessibility.resumeRecording.label": {
+      "comment": "Accessibility label for resume recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme fortsetzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resume Recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume Recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reanudar grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reprendre l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprendre l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を再開"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を再開"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复录音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复录音"
           }
         }
       }
     },
-    "menubar.accessibility.settings.hint" : {
-      "comment" : "Accessibility hint for settings link",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öffnet die Anwendungseinstellungen. Tastenkombination: Befehl Komma"
+    "menubar.accessibility.settings.hint": {
+      "comment": "Accessibility hint for settings link",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnet die Anwendungseinstellungen. Tastenkombination: Befehl Komma"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opens application settings. Keyboard shortcut: Command Comma"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens application settings. Keyboard shortcut: Command Comma"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abre la configuración de la aplicación. Atajo de teclado: Comando Coma"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre la configuración de la aplicación. Atajo de teclado: Comando Coma"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvre les réglages de l'application. Raccourci clavier : Commande Virgule"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvre les réglages de l'application. Raccourci clavier : Commande Virgule"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリケーション設定を開きます。キーボードショートカット：Command カンマ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーション設定を開きます。キーボードショートカット：Command カンマ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开应用程序设置。键盘快捷键：Command 逗号"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开应用程序设置。键盘快捷键：Command 逗号"
           }
         }
       }
     },
-    "menubar.accessibility.settings.label" : {
-      "comment" : "Accessibility label for settings link",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen"
+    "menubar.accessibility.settings.label": {
+      "comment": "Accessibility label for settings link",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réglages"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
           }
         }
       }
     },
-    "menubar.accessibility.startRecording.hint" : {
-      "comment" : "Accessibility hint for start recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beginnt eine neue Aufnahmesitzung. Tastenkombination: Befehl Umschalt R"
+    "menubar.accessibility.startRecording.hint": {
+      "comment": "Accessibility hint for start recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beginnt eine neue Aufnahmesitzung. Tastenkombination: Befehl Umschalt R"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Begins a new recording session. Keyboard shortcut: Command Shift R"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Begins a new recording session. Keyboard shortcut: Command Shift R"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicia una nueva sesión de grabación. Atajo de teclado: Comando Mayús R"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia una nueva sesión de grabación. Atajo de teclado: Comando Mayús R"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commence une nouvelle session d'enregistrement. Raccourci clavier : Commande Maj R"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commence une nouvelle session d'enregistrement. Raccourci clavier : Commande Maj R"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新しい録音セッションを開始します。キーボードショートカット：Command Shift R"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しい録音セッションを開始します。キーボードショートカット：Command Shift R"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "开始新的录音会话。键盘快捷键：Command Shift R"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始新的录音会话。键盘快捷键：Command Shift R"
           }
         }
       }
     },
-    "menubar.accessibility.startRecording.label" : {
-      "comment" : "Accessibility label for start recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme starten"
+    "menubar.accessibility.startRecording.label": {
+      "comment": "Accessibility label for start recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme starten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start Recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Démarrer l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を開始"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を開始"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "开始录音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始录音"
           }
         }
       }
     },
-    "menubar.accessibility.stopRecording.hint" : {
-      "comment" : "Accessibility hint for stop recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stoppt die Aufnahme und speichert die Transkription. Tastenkombination: Befehl Umschalt S"
+    "menubar.accessibility.stopRecording.hint": {
+      "comment": "Accessibility hint for stop recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stoppt die Aufnahme und speichert die Transkription. Tastenkombination: Befehl Umschalt S"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stops the recording and saves the transcript. Keyboard shortcut: Command Shift S"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stops the recording and saves the transcript. Keyboard shortcut: Command Shift S"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detiene la grabación y guarda la transcripción. Atajo de teclado: Comando Mayús S"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detiene la grabación y guarda la transcripción. Atajo de teclado: Comando Mayús S"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrête l'enregistrement et enregistre la transcription. Raccourci clavier : Commande Maj S"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrête l'enregistrement et enregistre la transcription. Raccourci clavier : Commande Maj S"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を停止し、文字起こしを保存します。キーボードショートカット：Command Shift S"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を停止し、文字起こしを保存します。キーボードショートカット：Command Shift S"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止录音并保存转录。键盘快捷键：Command Shift S"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止录音并保存转录。键盘快捷键：Command Shift S"
           }
         }
       }
     },
-    "menubar.accessibility.stopRecording.label" : {
-      "comment" : "Accessibility label for stop recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme stoppen"
+    "menubar.accessibility.stopRecording.label": {
+      "comment": "Accessibility label for stop recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme stoppen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop Recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detener grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detener grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrêter l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を停止"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止录音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止录音"
           }
         }
       }
     },
-    "menubar.alert.button.ok" : {
-      "comment" : "OK button label in alert dialog",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+    "menubar.alert.button.ok": {
+      "comment": "OK button label in alert dialog",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aceptar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "好"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
           }
         }
       }
     },
-    "menubar.alert.error.title" : {
-      "comment" : "Title for error alert dialog",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahmefehler"
+    "menubar.alert.error.title": {
+      "comment": "Title for error alert dialog",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmefehler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording Error"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording Error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur d'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur d'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音エラー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音エラー"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音错误"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音错误"
           }
         }
       }
     },
-    "menubar.announcement.recordingPaused" : {
-      "comment" : "VoiceOver announcement when recording pauses",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme pausiert"
+    "menubar.announcement.recordingPaused": {
+      "comment": "VoiceOver announcement when recording pauses",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme pausiert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording paused"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording paused"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grabación pausada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabación pausada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrement mis en pause"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement mis en pause"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を一時停止しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を一時停止しました"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音已暂停"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音已暂停"
           }
         }
       }
     },
-    "menubar.announcement.recordingResumed" : {
-      "comment" : "VoiceOver announcement when recording resumes",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme fortgesetzt"
+    "menubar.announcement.recordingResumed": {
+      "comment": "VoiceOver announcement when recording resumes",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme fortgesetzt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording resumed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording resumed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grabación reanudada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabación reanudada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrement repris"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement repris"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を再開しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を再開しました"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音已继续"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音已继续"
           }
         }
       }
     },
-    "menubar.announcement.recordingStarted" : {
-      "comment" : "VoiceOver announcement when recording starts",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme gestartet"
+    "menubar.announcement.recordingStarted": {
+      "comment": "VoiceOver announcement when recording starts",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme gestartet"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording started"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording started"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grabación iniciada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabación iniciada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrement démarré"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement démarré"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を開始しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を開始しました"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音已开始"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音已开始"
           }
         }
       }
     },
-    "menubar.announcement.recordingStopped" : {
-      "comment" : "VoiceOver announcement when recording stops",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme gestoppt"
+    "menubar.announcement.recordingStopped": {
+      "comment": "VoiceOver announcement when recording stops",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme gestoppt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording stopped"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording stopped"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grabación detenida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabación detenida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrement arrêté"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement arrêté"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を停止しました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を停止しました"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音已停止"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音已停止"
           }
         }
       }
     },
-    "menubar.button.pauseRecording" : {
-      "comment" : "Label for the pause recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme pausieren"
+    "menubar.button.pauseRecording": {
+      "comment": "Label for the pause recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme pausieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause Recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause Recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausar grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausar grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mettre en pause"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre en pause"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を一時停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を一時停止"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暂停录音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂停录音"
           }
         }
       }
     },
-    "menubar.button.quit" : {
-      "comment" : "Label for the quit button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beenden"
+    "menubar.button.quit": {
+      "comment": "Label for the quit button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beenden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quit"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salir"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quitter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "終了"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
           }
         }
       }
     },
-    "menubar.button.resumeRecording" : {
-      "comment" : "Label for the resume recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme fortsetzen"
+    "menubar.button.resumeRecording": {
+      "comment": "Label for the resume recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme fortsetzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resume Recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume Recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reanudar grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reprendre l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprendre l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を再開"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を再開"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "继续录音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续录音"
           }
         }
       }
     },
-    "menubar.button.startRecording" : {
-      "comment" : "Label for the start recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme starten"
+    "menubar.button.startRecording": {
+      "comment": "Label for the start recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme starten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start Recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Démarrer l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を開始"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を開始"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "开始录音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始录音"
           }
         }
       }
     },
-    "menubar.button.stopRecording" : {
-      "comment" : "Label for the stop recording button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme stoppen"
+    "menubar.button.stopRecording": {
+      "comment": "Label for the stop recording button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme stoppen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop Recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detener grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detener grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrêter l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を停止"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止录音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止录音"
           }
         }
       }
     },
-    "menubar.link.settings" : {
-      "comment" : "Label for the settings link",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen..."
+    "menubar.link.settings": {
+      "comment": "Label for the settings link",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réglages..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置..."
           }
         }
       }
     },
-    "menubar.status.paused" : {
-      "comment" : "Prefix for paused status display (e.g., 'Paused: 00:15')",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausiert: %@"
+    "menubar.status.paused": {
+      "comment": "Prefix for paused status display (e.g., 'Paused: 00:15')",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausiert: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paused: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paused: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En pausa: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En pausa: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En pause : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En pause : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時停止中: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一時停止中: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已暂停：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已暂停：%@"
           }
         }
       }
     },
-    "menubar.status.recording" : {
-      "comment" : "Prefix for recording status display (e.g., 'Recording: 00:15')",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahme: %@"
+    "menubar.status.recording": {
+      "comment": "Prefix for recording status display (e.g., 'Recording: 00:15')",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grabando: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabando: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrement : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音中：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音中：%@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音中：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音中：%@"
           }
         }
       }
     },
-    "settings.audioSources.captureMicrophone.accessibility.hint" : {
-      "comment" : "Capture microphone accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn aktiviert, nimmt Audio von Ihrem Mikrofon auf"
+    "settings.audioSources.captureMicrophone.accessibility.hint": {
+      "comment": "Capture microphone accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn aktiviert, nimmt Audio von Ihrem Mikrofon auf"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Records audio from your microphone. At least one audio source must be enabled"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Records audio from your microphone. At least one audio source must be enabled"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cuando está habilitado, graba el audio de tu micrófono"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuando está habilitado, graba el audio de tu micrófono"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lorsqu'il est activé, enregistre l'audio de votre microphone"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lorsqu'il est activé, enregistre l'audio de votre microphone"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効にすると、マイクからオーディオを録音します"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効にすると、マイクからオーディオを録音します"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用后，录制麦克风的音频"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用后，录制麦克风的音频"
           }
         }
       }
     },
-    "settings.audioSources.captureMicrophone.accessibility.label" : {
-      "comment" : "Capture microphone accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofon aufnehmen"
+    "settings.audioSources.captureMicrophone.accessibility.label": {
+      "comment": "Capture microphone accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon aufnehmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capture Microphone Input"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture Microphone Input"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capturar micrófono"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturar micrófono"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capturer le microphone"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturer le microphone"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "マイクをキャプチャ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マイクをキャプチャ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "捕获麦克风"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕获麦克风"
           }
         }
       }
     },
-    "settings.audioSources.captureMicrophone.label" : {
-      "comment" : "Capture microphone toggle label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofon aufnehmen"
+    "settings.audioSources.captureMicrophone.label": {
+      "comment": "Capture microphone toggle label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon aufnehmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capture Microphone Input"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture Microphone Input"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capturar micrófono"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturar micrófono"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capturer le microphone"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturer le microphone"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "マイクをキャプチャ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マイクをキャプチャ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "捕获麦克风"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕获麦克风"
           }
         }
       }
     },
-    "settings.audioSources.captureSystemAudio.accessibility.hint" : {
-      "comment" : "Capture system audio accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn aktiviert, nimmt Audio von anderen Anwendungen auf Ihrem Mac auf"
+    "settings.audioSources.captureSystemAudio.accessibility.hint": {
+      "comment": "Capture system audio accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn aktiviert, nimmt Audio von anderen Anwendungen auf Ihrem Mac auf"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Records audio from applications like Zoom, Teams, and other system sounds"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Records audio from applications like Zoom, Teams, and other system sounds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cuando está habilitado, graba el audio de otras aplicaciones en tu Mac"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuando está habilitado, graba el audio de otras aplicaciones en tu Mac"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lorsqu'il est activé, enregistre l'audio d'autres applications sur votre Mac"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lorsqu'il est activé, enregistre l'audio d'autres applications sur votre Mac"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効にすると、Mac上の他のアプリケーションからオーディオを録音します"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効にすると、Mac上の他のアプリケーションからオーディオを録音します"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用后，录制Mac上其他应用程序的音频"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用后，录制Mac上其他应用程序的音频"
           }
         }
       }
     },
-    "settings.audioSources.captureSystemAudio.accessibility.label" : {
-      "comment" : "Capture system audio accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System-Audio aufnehmen"
+    "settings.audioSources.captureSystemAudio.accessibility.label": {
+      "comment": "Capture system audio accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System-Audio aufnehmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capture System Audio"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture System Audio"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capturar audio del sistema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturar audio del sistema"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capturer l'audio système"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturer l'audio système"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムオーディオをキャプチャ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムオーディオをキャプチャ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "捕获系统音频"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕获系统音频"
           }
         }
       }
     },
-    "settings.audioSources.captureSystemAudio.label" : {
-      "comment" : "Capture system audio toggle label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System-Audio aufnehmen"
+    "settings.audioSources.captureSystemAudio.label": {
+      "comment": "Capture system audio toggle label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System-Audio aufnehmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capture System Audio (Zoom, Teams, etc.)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture System Audio (Zoom, Teams, etc.)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capturar audio del sistema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturar audio del sistema"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capturer l'audio système"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturer l'audio système"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムオーディオをキャプチャ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムオーディオをキャプチャ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "捕获系统音频"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕获系统音频"
           }
         }
       }
     },
-    "settings.audioSources.header" : {
-      "comment" : "Audio sources section header",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audioquellen"
+    "settings.audioSources.header": {
+      "comment": "Audio sources section header",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioquellen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio Sources"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio Sources"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fuentes de audio"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuentes de audio"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sources audio"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sources audio"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音声ソース"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声ソース"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "音频源"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频源"
           }
         }
       }
     },
-    "settings.display.header" : {
-      "comment" : "Display section header",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anzeige"
+    "settings.display.header": {
+      "comment": "Display section header",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeige"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Display"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pantalla"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pantalla"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Affichage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affichage"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示"
           }
         }
       }
     },
-    "settings.display.helpText" : {
-      "comment" : "Display section help text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passen Sie an, wie Aufnahmeninformationen in der Menüleiste angezeigt werden"
+    "settings.display.helpText": {
+      "comment": "Display section help text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passen Sie an, wie Aufnahmeninformationen in der Menüleiste angezeigt werden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Customize how recording information is displayed in the menu bar"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Customize how recording information is displayed in the menu bar"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personaliza cómo se muestra la información de grabación en la barra de menú"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personaliza cómo se muestra la información de grabación en la barra de menú"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personnalisez l'affichage des informations d'enregistrement dans la barre de menus"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnalisez l'affichage des informations d'enregistrement dans la barre de menus"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーに録音情報を表示する方法をカスタマイズします"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバーに録音情報を表示する方法をカスタマイズします"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自定义菜单栏中录音信息的显示方式"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义菜单栏中录音信息的显示方式"
           }
         }
       }
     },
-    "settings.display.showRecordingTimeInMenuBar.accessibility.hint" : {
-      "comment" : "Show recording time in menu bar accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn aktiviert, zeigt die Menüleiste die verstrichene Zeit neben dem Aufnahmeindikator an"
+    "settings.display.showRecordingTimeInMenuBar.accessibility.hint": {
+      "comment": "Show recording time in menu bar accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn aktiviert, zeigt die Menüleiste die verstrichene Zeit neben dem Aufnahmeindikator an"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When enabled, displays elapsed time next to the recording indicator in the menu bar"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When enabled, displays elapsed time next to the recording indicator in the menu bar"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cuando está habilitado, muestra el tiempo transcurrido junto al indicador de grabación en la barra de menú"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuando está habilitado, muestra el tiempo transcurrido junto al indicador de grabación en la barra de menú"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lorsqu'il est activé, affiche le temps écoulé à côté de l'indicateur d'enregistrement dans la barre de menus"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lorsqu'il est activé, affiche le temps écoulé à côté de l'indicateur d'enregistrement dans la barre de menus"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効にすると、メニューバーの録音インジケーターの横に経過時間が表示されます"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効にすると、メニューバーの録音インジケーターの横に経過時間が表示されます"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用后，在菜单栏的录音指示器旁显示经过的时间"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用后，在菜单栏的录音指示器旁显示经过的时间"
           }
         }
       }
     },
-    "settings.display.showRecordingTimeInMenuBar.accessibility.label" : {
-      "comment" : "Show recording time in menu bar accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahmezeit in Menüleiste anzeigen"
+    "settings.display.showRecordingTimeInMenuBar.accessibility.label": {
+      "comment": "Show recording time in menu bar accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmezeit in Menüleiste anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show recording time in menu bar"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show recording time in menu bar"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar tiempo de grabación en la barra de menú"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar tiempo de grabación en la barra de menú"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher le temps d'enregistrement dans la barre de menus"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher le temps d'enregistrement dans la barre de menus"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーに録音時間を表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバーに録音時間を表示"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在菜单栏中显示录音时间"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在菜单栏中显示录音时间"
           }
         }
       }
     },
-    "settings.display.showRecordingTimeInMenuBar.label" : {
-      "comment" : "Show recording time in menu bar toggle label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufnahmezeit in Menüleiste anzeigen"
+    "settings.display.showRecordingTimeInMenuBar.label": {
+      "comment": "Show recording time in menu bar toggle label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmezeit in Menüleiste anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show recording time in menu bar"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show recording time in menu bar"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar tiempo de grabación en la barra de menú"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar tiempo de grabación en la barra de menú"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher le temps d'enregistrement dans la barre de menus"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher le temps d'enregistrement dans la barre de menus"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーに録音時間を表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバーに録音時間を表示"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在菜单栏中显示录音时间"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在菜单栏中显示录音时间"
           }
         }
       }
     },
-    "settings.audioSources.helpText" : {
-      "comment" : "Audio sources help text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sie können System-Audio (von anderen Anwendungen), Ihr Mikrofon oder beides aufnehmen. Mindestens eine Quelle muss aktiviert sein."
+    "settings.audioSources.helpText": {
+      "comment": "Audio sources help text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie können System-Audio (von anderen Anwendungen), Ihr Mikrofon oder beides aufnehmen. Mindestens eine Quelle muss aktiviert sein."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "At least one audio source must be enabled"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "At least one audio source must be enabled"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puedes capturar audio del sistema (de otras aplicaciones), tu micrófono o ambos. Al menos una fuente debe estar habilitada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puedes capturar audio del sistema (de otras aplicaciones), tu micrófono o ambos. Al menos una fuente debe estar habilitada."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous pouvez capturer l'audio du système (d'autres applications), votre microphone ou les deux. Au moins une source doit être activée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous pouvez capturer l'audio du système (d'autres applications), votre microphone ou les deux. Au moins une source doit être activée."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムオーディオ（他のアプリケーションから）、マイク、または両方をキャプチャできます。少なくとも1つのソースを有効にする必要があります。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムオーディオ（他のアプリケーションから）、マイク、または両方をキャプチャできます。少なくとも1つのソースを有効にする必要があります。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您可以捕获系统音频（来自其他应用程序）、麦克风或两者。必须启用至少一个来源。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您可以捕获系统音频（来自其他应用程序）、麦克风或两者。必须启用至少一个来源。"
           }
         }
       }
     },
-    "settings.filenameTemplate.accessibility.hint" : {
-      "comment" : "Filename template accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geben Sie eine Vorlage für Transkriptionsdateinamen mit {date} und {time} ein"
+    "settings.filenameTemplate.accessibility.hint": {
+      "comment": "Filename template accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geben Sie eine Vorlage für Transkriptionsdateinamen mit {date} und {time} ein"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter a template for transcript filenames using {date} and {time} tokens"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a template for transcript filenames using {date} and {time} tokens"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingrese una plantilla para nombres de archivos de transcripción usando {date} y {time}"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingrese una plantilla para nombres de archivos de transcripción usando {date} y {time}"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrez un modèle pour les noms de fichiers de transcription en utilisant {date} et {time}"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entrez un modèle pour les noms de fichiers de transcription en utilisant {date} et {time}"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "{date} と {time} トークンを使用してトランスクリプトファイル名のテンプレートを入力"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "{date} と {time} トークンを使用してトランスクリプトファイル名のテンプレートを入力"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用 {date} 和 {time} 标记输入转录文件名模板"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 {date} 和 {time} 标记输入转录文件名模板"
           }
         }
       }
     },
-    "settings.filenameTemplate.accessibility.label" : {
-      "comment" : "Filename template accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dateinamenvorlage"
+    "settings.filenameTemplate.accessibility.label": {
+      "comment": "Filename template accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateinamenvorlage"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filename template"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filename template"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plantilla de nombre de archivo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plantilla de nombre de archivo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modèle de nom de fichier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèle de nom de fichier"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ファイル名テンプレート"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル名テンプレート"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文件名模板"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件名模板"
           }
         }
       }
     },
-    "settings.filenameTemplate.helpText" : {
-      "comment" : "Filename template help text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwenden Sie {date} und {time} für dynamische Werte. Beispiel: meeting_{date}_{time}.txt"
+    "settings.filenameTemplate.helpText": {
+      "comment": "Filename template help text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden Sie {date} und {time} für dynamische Werte. Beispiel: meeting_{date}_{time}.txt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use {date} and {time} for dynamic values. Example: meeting_{date}_{time}.txt"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use {date} and {time} for dynamic values. Example: meeting_{date}_{time}.txt"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use {date} y {time} para valores dinámicos. Ejemplo: reunion_{date}_{time}.txt"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use {date} y {time} para valores dinámicos. Ejemplo: reunion_{date}_{time}.txt"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisez {date} et {time} pour les valeurs dynamiques. Exemple: reunion_{date}_{time}.txt"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisez {date} et {time} pour les valeurs dynamiques. Exemple: reunion_{date}_{time}.txt"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "動的な値には {date} と {time} を使用します。例: meeting_{date}_{time}.txt"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "動的な値には {date} と {time} を使用します。例: meeting_{date}_{time}.txt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用 {date} 和 {time} 作为动态值。示例：meeting_{date}_{time}.txt"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 {date} 和 {time} 作为动态值。示例：meeting_{date}_{time}.txt"
           }
         }
       }
     },
-    "settings.filenameTemplate.label" : {
-      "comment" : "Filename template field label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dateinamenvorlage"
+    "settings.filenameTemplate.label": {
+      "comment": "Filename template field label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateinamenvorlage"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filename Template"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filename Template"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plantilla de nombre de archivo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plantilla de nombre de archivo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modèle de nom de fichier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèle de nom de fichier"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ファイル名テンプレート"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル名テンプレート"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文件名模板"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件名模板"
           }
         }
       }
     },
-    "settings.output.folder.accessibility.hint" : {
-      "comment" : "Output folder accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pfad des Ordners, in dem Transkriptionen gespeichert werden"
+    "settings.output.folder.accessibility.hint": {
+      "comment": "Output folder accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pfad des Ordners, in dem Transkriptionen gespeichert werden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Path where transcripts will be saved"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path where transcripts will be saved"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruta de la carpeta donde se guardarán las transcripciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta de la carpeta donde se guardarán las transcripciones"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chemin du dossier où les transcriptions seront enregistrées"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin du dossier où les transcriptions seront enregistrées"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トランスクリプトが保存されるフォルダのパス"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスクリプトが保存されるフォルダのパス"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存转录的文件夹路径"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存转录的文件夹路径"
           }
         }
       }
     },
-    "settings.output.folder.accessibility.label" : {
-      "comment" : "Output folder accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgabeordner"
+    "settings.output.folder.accessibility.label": {
+      "comment": "Output folder accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgabeordner"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Output Folder"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output Folder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Carpeta de salida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carpeta de salida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dossier de sortie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dossier de sortie"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "出力フォルダ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "出力フォルダ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "输出文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输出文件夹"
           }
         }
       }
     },
-    "settings.output.folder.browse.accessibility.hint" : {
-      "comment" : "Browse button accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öffnet einen Dialog zur Auswahl des Ausgabeordners"
+    "settings.output.folder.browse.accessibility.hint": {
+      "comment": "Browse button accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnet einen Dialog zur Auswahl des Ausgabeordners"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opens a dialog to select where transcripts will be saved"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens a dialog to select where transcripts will be saved"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abre un diálogo para seleccionar la carpeta de salida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre un diálogo para seleccionar la carpeta de salida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvre une boîte de dialogue pour sélectionner le dossier de sortie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvre une boîte de dialogue pour sélectionner le dossier de sortie"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "出力フォルダを選択するダイアログを開きます"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "出力フォルダを選択するダイアログを開きます"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开对话框以选择输出文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开对话框以选择输出文件夹"
           }
         }
       }
     },
-    "settings.output.folder.browse.accessibility.label" : {
-      "comment" : "Browse button accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgabeordner durchsuchen"
+    "settings.output.folder.browse.accessibility.label": {
+      "comment": "Browse button accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgabeordner durchsuchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browse for Output Folder"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse for Output Folder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Examinar carpeta de salida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Examinar carpeta de salida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parcourir le dossier de sortie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcourir le dossier de sortie"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "出力フォルダを参照"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "出力フォルダを参照"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "浏览输出文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览输出文件夹"
           }
         }
       }
     },
-    "settings.output.folder.browseButton" : {
-      "comment" : "Browse button for output folder",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durchsuchen…"
+    "settings.output.folder.browseButton": {
+      "comment": "Browse button for output folder",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durchsuchen…"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browse..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Examinar…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Examinar…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parcourir…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcourir…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "参照…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参照…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "浏览…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览…"
           }
         }
       }
     },
-    "settings.output.folder.dialog.message" : {
-      "comment" : "Output folder dialog message",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie den Ordner aus, in dem Transkriptionen gespeichert werden"
+    "settings.output.folder.dialog.message": {
+      "comment": "Output folder dialog message",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie den Ordner aus, in dem Transkriptionen gespeichert werden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose where transcripts will be saved"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose where transcripts will be saved"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige la carpeta donde se guardarán las transcripciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige la carpeta donde se guardarán las transcripciones"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez le dossier où les transcriptions seront enregistrées"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez le dossier où les transcriptions seront enregistrées"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トランスクリプトを保存するフォルダを選択してください"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスクリプトを保存するフォルダを選択してください"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择保存转录的文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择保存转录的文件夹"
           }
         }
       }
     },
-    "settings.output.folder.dialog.prompt" : {
-      "comment" : "Output folder dialog prompt",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auswählen"
+    "settings.output.folder.dialog.prompt": {
+      "comment": "Output folder dialog prompt",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auswählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select Output Folder"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Output Folder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择"
           }
         }
       }
     },
-    "settings.output.folder.label" : {
-      "comment" : "Output folder text field label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgabeordner"
+    "settings.output.folder.label": {
+      "comment": "Output folder text field label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgabeordner"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Output Folder"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output Folder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Carpeta de salida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carpeta de salida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dossier de sortie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dossier de sortie"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "出力フォルダ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "出力フォルダ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "输出文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输出文件夹"
           }
         }
       }
     },
-    "settings.output.header" : {
-      "comment" : "Output section header",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgabe"
+    "settings.output.header": {
+      "comment": "Output section header",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgabe"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Output"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Output"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salida"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sortie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sortie"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "出力"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "出力"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "输出"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输出"
           }
         }
       }
     },
-    "settings.output.helpText" : {
-      "comment" : "Output section help text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkriptionen werden in diesem Ordner gespeichert. Das Original-Audio wird neben der Transkription gespeichert, wenn aktiviert."
+    "settings.output.helpText": {
+      "comment": "Output section help text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionen werden in diesem Ordner gespeichert. Das Original-Audio wird neben der Transkription gespeichert, wenn aktiviert."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transcripts will be saved to this folder. When enabled, original audio recordings will also be saved in M4A format."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcripts will be saved to this folder. When enabled, original audio recordings will also be saved in M4A format."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las transcripciones se guardarán en esta carpeta. El audio original se guardará junto a la transcripción si está habilitado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las transcripciones se guardarán en esta carpeta. El audio original se guardará junto a la transcripción si está habilitado."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les transcriptions seront enregistrées dans ce dossier. L'audio d'origine sera enregistré à côté de la transcription si activé."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les transcriptions seront enregistrées dans ce dossier. L'audio d'origine sera enregistré à côté de la transcription si activé."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トランスクリプトはこのフォルダに保存されます。有効にすると、元の音声がトランスクリプトと一緒に保存されます。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスクリプトはこのフォルダに保存されます。有効にすると、元の音声がトランスクリプトと一緒に保存されます。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "转录将保存在此文件夹中。如果启用，原始音频将保存在转录旁边。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录将保存在此文件夹中。如果启用，原始音频将保存在转录旁边。"
           }
         }
       }
     },
-    "settings.output.saveOriginalAudio.accessibility.hint" : {
-      "comment" : "Save original audio accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn aktiviert, wird die rohe Audiodatei neben der Transkription gespeichert"
+    "settings.output.saveOriginalAudio.accessibility.hint": {
+      "comment": "Save original audio accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn aktiviert, wird die rohe Audiodatei neben der Transkription gespeichert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When enabled, saves original audio recordings in M4A format alongside transcripts"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When enabled, saves original audio recordings in M4A format alongside transcripts"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cuando está habilitado, guarda el archivo de audio sin procesar junto con la transcripción"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuando está habilitado, guarda el archivo de audio sin procesar junto con la transcripción"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lorsqu'il est activé, enregistre le fichier audio brut à côté de la transcription"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lorsqu'il est activé, enregistre le fichier audio brut à côté de la transcription"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効にすると、トランスクリプトと一緒に生の音声ファイルが保存されます"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効にすると、トランスクリプトと一緒に生の音声ファイルが保存されます"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用后，将原始音频文件与转录一起保存"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用后，将原始音频文件与转录一起保存"
           }
         }
       }
     },
-    "settings.output.saveOriginalAudio.accessibility.label" : {
-      "comment" : "Save original audio accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Original-Audio speichern"
+    "settings.output.saveOriginalAudio.accessibility.label": {
+      "comment": "Save original audio accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Original-Audio speichern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save Original Audio File"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Original Audio File"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar audio original"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar audio original"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrer l'audio d'origine"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer l'audio d'origine"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "元の音声を保存"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "元の音声を保存"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存原始音频"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存原始音频"
           }
         }
       }
     },
-    "settings.output.saveOriginalAudio.label" : {
-      "comment" : "Save original audio toggle label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Original-Audio speichern"
+    "settings.output.saveOriginalAudio.label": {
+      "comment": "Save original audio toggle label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Original-Audio speichern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save Original Audio File"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Original Audio File"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar audio original"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar audio original"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrer l'audio d'origine"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer l'audio d'origine"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "元の音声を保存"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "元の音声を保存"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存原始音频"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存原始音频"
           }
         }
       }
     },
-    "settings.output.revealTranscriptInFinder.accessibility.hint" : {
-      "comment" : "Reveal transcript in Finder accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn aktiviert, öffnet Finder und wählt die Transkriptdatei aus, wenn die Aufnahme stoppt"
+    "settings.output.revealTranscriptInFinder.accessibility.hint": {
+      "comment": "Reveal transcript in Finder accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn aktiviert, öffnet Finder und wählt die Transkriptdatei aus, wenn die Aufnahme stoppt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When enabled, opens Finder and selects the transcript file when recording stops"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When enabled, opens Finder and selects the transcript file when recording stops"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cuando está habilitado, abre Finder y selecciona el archivo de transcripción cuando se detiene la grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuando está habilitado, abre Finder y selecciona el archivo de transcripción cuando se detiene la grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lorsqu'il est activé, ouvre le Finder et sélectionne le fichier de transcription lorsque l'enregistrement s'arrête"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lorsqu'il est activé, ouvre le Finder et sélectionne le fichier de transcription lorsque l'enregistrement s'arrête"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効にすると、録音が停止したときにFinderが開き、転写ファイルが選択されます"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効にすると、録音が停止したときにFinderが開き、転写ファイルが選択されます"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用后，录音停止时会打开访达并选择转录文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用后，录音停止时会打开访达并选择转录文件"
           }
         }
       }
     },
-    "settings.output.revealTranscriptInFinder.accessibility.label" : {
-      "comment" : "Reveal transcript in Finder accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkript im Finder anzeigen"
+    "settings.output.revealTranscriptInFinder.accessibility.label": {
+      "comment": "Reveal transcript in Finder accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkript im Finder anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reveal Transcript in Finder"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal Transcript in Finder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar transcripción en Finder"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar transcripción en Finder"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher la transcription dans le Finder"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher la transcription dans le Finder"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finderで転写を表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finderで転写を表示"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在访达中显示转录"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在访达中显示转录"
           }
         }
       }
     },
-    "settings.output.revealTranscriptInFinder.label" : {
-      "comment" : "Reveal transcript in Finder toggle label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transkript im Finder anzeigen"
+    "settings.output.revealTranscriptInFinder.label": {
+      "comment": "Reveal transcript in Finder toggle label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkript im Finder anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reveal Transcript in Finder"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal Transcript in Finder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar transcripción en Finder"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar transcripción en Finder"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher la transcription dans le Finder"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher la transcription dans le Finder"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finderで転写を表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finderで転写を表示"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在访达中显示转录"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在访达中显示转录"
           }
         }
       }
     },
-    "settings.postRecording.action.doNothing" : {
-      "comment" : "Do nothing radio option",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nichts tun"
+    "settings.postRecording.action.doNothing": {
+      "comment": "Do nothing radio option",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nichts tun"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Do nothing"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do nothing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hacer nada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hacer nada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ne rien faire"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne rien faire"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "何もしない"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "何もしない"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不执行操作"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不执行操作"
           }
         }
       }
     },
-    "settings.postRecording.action.runScript" : {
-      "comment" : "Run script radio option",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skript ausführen"
+    "settings.postRecording.action.runScript": {
+      "comment": "Run script radio option",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skript ausführen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Run a script"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run a script"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ejecutar script"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar script"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exécuter un script"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécuter un script"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトを実行"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトを実行"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行脚本"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行脚本"
           }
         }
       }
     },
-    "settings.postRecording.action.runShortcut" : {
-      "comment" : "Run shortcut radio option",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shortcut ausführen"
+    "settings.postRecording.action.runShortcut": {
+      "comment": "Run shortcut radio option",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut ausführen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Run a shortcut"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run a shortcut"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ejecutar atajo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar atajo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exécuter un raccourci"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécuter un raccourci"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ショートカットを実行"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットを実行"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行快捷指令"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行快捷指令"
           }
         }
       }
     },
-    "settings.postRecording.afterRecording.accessibility.hint" : {
-      "comment" : "After recording accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie aus, was nach dem Stoppen einer Aufnahme passieren soll"
+    "settings.postRecording.afterRecording.accessibility.hint": {
+      "comment": "After recording accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie aus, was nach dem Stoppen einer Aufnahme passieren soll"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose what happens when recording stops: do nothing, run a script, or run a shortcut"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose what happens when recording stops: do nothing, run a script, or run a shortcut"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecciona qué hacer después de detener una grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona qué hacer después de detener una grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez quoi faire après l'arrêt d'un enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez quoi faire après l'arrêt d'un enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音を停止した後に実行する操作を選択します"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音を停止した後に実行する操作を選択します"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择停止录音后要执行的操作"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择停止录音后要执行的操作"
           }
         }
       }
     },
-    "settings.postRecording.afterRecording.accessibility.label" : {
-      "comment" : "After recording accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktion nach der Aufnahme"
+    "settings.postRecording.afterRecording.accessibility.label": {
+      "comment": "After recording accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktion nach der Aufnahme"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "After recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acción después de grabar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acción después de grabar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Action après l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Action après l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音後のアクション"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音後のアクション"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音后操作"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音后操作"
           }
         }
       }
     },
-    "settings.postRecording.afterRecording.label" : {
-      "comment" : "After recording picker label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach dem Stoppen der Aufnahme"
+    "settings.postRecording.afterRecording.label": {
+      "comment": "After recording picker label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach dem Stoppen der Aufnahme"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "After recording:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After recording:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Después de detener la grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Después de detener la grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Après l'arrêt de l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Après l'arrêt de l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音停止後"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音停止後"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止录音后"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止录音后"
           }
         }
       }
     },
-    "settings.postRecording.header" : {
-      "comment" : "Post-recording section header",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach der Aufnahme"
+    "settings.postRecording.header": {
+      "comment": "Post-recording section header",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach der Aufnahme"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Post-Recording Action"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Post-Recording Action"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Después de grabar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Después de grabar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Après l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Après l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音後"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音後"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "录音后"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音后"
           }
         }
       }
     },
-    "settings.postRecording.script.browse.accessibility.hint" : {
-      "comment" : "Script browse accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öffnet einen Dialog zur Auswahl der Skriptdatei"
+    "settings.postRecording.script.browse.accessibility.hint": {
+      "comment": "Script browse accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnet einen Dialog zur Auswahl der Skriptdatei"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opens a dialog to select a shell script to run after recording"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens a dialog to select a shell script to run after recording"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abre un diálogo para seleccionar el archivo de script"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre un diálogo para seleccionar el archivo de script"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvre une boîte de dialogue pour sélectionner le fichier de script"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvre une boîte de dialogue pour sélectionner le fichier de script"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトファイルを選択するダイアログを開きます"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトファイルを選択するダイアログを開きます"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开对话框以选择脚本文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开对话框以选择脚本文件"
           }
         }
       }
     },
-    "settings.postRecording.script.browse.accessibility.label" : {
-      "comment" : "Script browse accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skript durchsuchen"
+    "settings.postRecording.script.browse.accessibility.label": {
+      "comment": "Script browse accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skript durchsuchen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browse for Script"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse for Script"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Examinar script"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Examinar script"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parcourir le script"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcourir le script"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトを参照"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトを参照"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "浏览脚本"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览脚本"
           }
         }
       }
     },
-    "settings.postRecording.script.browseButton" : {
-      "comment" : "Browse button for script",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durchsuchen…"
+    "settings.postRecording.script.browseButton": {
+      "comment": "Browse button for script",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durchsuchen…"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browse..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Examinar…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Examinar…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parcourir…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcourir…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "参照…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参照…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "浏览…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览…"
           }
         }
       }
     },
-    "settings.postRecording.script.dialog.message" : {
-      "comment" : "Script dialog message",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie das Skript aus, das nach dem Stoppen der Aufnahme ausgeführt wird"
+    "settings.postRecording.script.dialog.message": {
+      "comment": "Script dialog message",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie das Skript aus, das nach dem Stoppen der Aufnahme ausgeführt wird"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose a shell script to run after recording completes"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a shell script to run after recording completes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige el script que se ejecutará después de detener la grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige el script que se ejecutará después de detener la grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez le script à exécuter après l'arrêt de l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez le script à exécuter après l'arrêt de l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音停止後に実行するスクリプトを選択してください"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音停止後に実行するスクリプトを選択してください"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择停止录音后要运行的脚本"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择停止录音后要运行的脚本"
           }
         }
       }
     },
-    "settings.postRecording.script.dialog.prompt" : {
-      "comment" : "Script dialog prompt",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auswählen"
+    "settings.postRecording.script.dialog.prompt": {
+      "comment": "Script dialog prompt",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auswählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select Script"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Script"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择"
           }
         }
       }
     },
-    "settings.postRecording.script.helpText" : {
-      "comment" : "Script help text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Skript erhält den Pfad der Transkriptionsdatei als erstes Argument. Stellen Sie sicher, dass das Skript ausführbar ist."
+    "settings.postRecording.script.helpText": {
+      "comment": "Script help text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Skript erhält den Pfad der Transkriptionsdatei als erstes Argument. Stellen Sie sicher, dass das Skript ausführbar ist."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Script receives transcript path as $1"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Script receives transcript path as $1"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El script recibirá la ruta del archivo de transcripción como primer argumento. Asegúrate de que el script sea ejecutable."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El script recibirá la ruta del archivo de transcripción como primer argumento. Asegúrate de que el script sea ejecutable."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le script recevra le chemin du fichier de transcription comme premier argument. Assurez-vous que le script est exécutable."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le script recevra le chemin du fichier de transcription comme premier argument. Assurez-vous que le script est exécutable."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトは最初の引数としてトランスクリプトファイルのパスを受け取ります。スクリプトが実行可能であることを確認してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトは最初の引数としてトランスクリプトファイルのパスを受け取ります。スクリプトが実行可能であることを確認してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脚本将接收转录文件路径作为第一个参数。确保脚本是可执行的。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "脚本将接收转录文件路径作为第一个参数。确保脚本是可执行的。"
           }
         }
       }
     },
-    "settings.postRecording.script.path.accessibility.hint" : {
-      "comment" : "Script path accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pfad zum Skript, das nach dem Stoppen der Aufnahme ausgeführt wird"
+    "settings.postRecording.script.path.accessibility.hint": {
+      "comment": "Script path accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pfad zum Skript, das nach dem Stoppen der Aufnahme ausgeführt wird"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Path to shell script that will receive the transcript file path as its first argument"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path to shell script that will receive the transcript file path as its first argument"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruta al script que se ejecutará después de detener la grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta al script que se ejecutará después de detener la grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chemin vers le script à exécuter après l'arrêt de l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin vers le script à exécuter après l'arrêt de l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音停止後に実行するスクリプトへのパス"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音停止後に実行するスクリプトへのパス"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止录音后要执行的脚本路径"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止录音后要执行的脚本路径"
           }
         }
       }
     },
-    "settings.postRecording.script.path.accessibility.label" : {
-      "comment" : "Script path accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skriptpfad"
+    "settings.postRecording.script.path.accessibility.label": {
+      "comment": "Script path accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriptpfad"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shell Script Path"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell Script Path"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruta del script"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta del script"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chemin du script"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin du script"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトパス"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトパス"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脚本路径"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "脚本路径"
           }
         }
       }
     },
-    "settings.postRecording.script.path.label" : {
-      "comment" : "Script path text field label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skriptpfad"
+    "settings.postRecording.script.path.label": {
+      "comment": "Script path text field label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriptpfad"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shell Script Path"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell Script Path"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruta del script"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta del script"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chemin du script"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin du script"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクリプトパス"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリプトパス"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脚本路径"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "脚本路径"
           }
         }
       }
     },
-    "settings.postRecording.shortcut.helpText" : {
-      "comment" : "Shortcut help text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Shortcut erhält den Pfad der Transkriptionsdatei als Eingabe."
+    "settings.postRecording.shortcut.helpText": {
+      "comment": "Shortcut help text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Shortcut erhält den Pfad der Transkriptionsdatei als Eingabe."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The shortcut receives the transcript file path as input"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The shortcut receives the transcript file path as input"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El atajo recibirá la ruta del archivo de transcripción como entrada."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El atajo recibirá la ruta del archivo de transcripción como entrada."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le raccourci recevra le chemin du fichier de transcription en entrée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le raccourci recevra le chemin du fichier de transcription en entrée."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ショートカットは入力としてトランスクリプトファイルのパスを受け取ります。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットは入力としてトランスクリプトファイルのパスを受け取ります。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "快捷指令将接收转录文件路径作为输入。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷指令将接收转录文件路径作为输入。"
           }
         }
       }
     },
-    "settings.postRecording.shortcut.loading" : {
-      "comment" : "Loading shortcuts text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shortcuts werden geladen…"
+    "settings.postRecording.shortcut.loading": {
+      "comment": "Loading shortcuts text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcuts werden geladen…"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading shortcuts..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading shortcuts..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargando atajos…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando atajos…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chargement des raccourcis…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement des raccourcis…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ショートカットを読み込んでいます…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットを読み込んでいます…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在加载快捷指令…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载快捷指令…"
           }
         }
       }
     },
-    "settings.postRecording.shortcut.loading.accessibility.label" : {
-      "comment" : "Loading shortcuts accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shortcuts werden geladen"
+    "settings.postRecording.shortcut.loading.accessibility.label": {
+      "comment": "Loading shortcuts accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcuts werden geladen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading shortcuts"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading shortcuts"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cargando atajos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cargando atajos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chargement des raccourcis"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chargement des raccourcis"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ショートカットを読み込み中"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットを読み込み中"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在加载快捷指令"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载快捷指令"
           }
         }
       }
     },
-    "settings.postRecording.shortcut.noShortcuts" : {
-      "comment" : "No shortcuts found message",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Shortcuts gefunden. Erstellen Sie Shortcuts in der Shortcuts-App."
+    "settings.postRecording.shortcut.noShortcuts": {
+      "comment": "No shortcuts found message",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Shortcuts gefunden. Erstellen Sie Shortcuts in der Shortcuts-App."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No shortcuts found. Create shortcuts in the Shortcuts app first."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No shortcuts found. Create shortcuts in the Shortcuts app first."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontraron atajos. Crea atajos en la aplicación Atajos."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontraron atajos. Crea atajos en la aplicación Atajos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun raccourci trouvé. Créez des raccourcis dans l'application Raccourcis."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun raccourci trouvé. Créez des raccourcis dans l'application Raccourcis."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ショートカットが見つかりません。ショートカットアプリでショートカットを作成してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットが見つかりません。ショートカットアプリでショートカットを作成してください。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到快捷指令。在快捷指令应用中创建快捷指令。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到快捷指令。在快捷指令应用中创建快捷指令。"
           }
         }
       }
     },
-    "settings.postRecording.shortcut.picker.accessibility.hint" : {
-      "comment" : "Shortcut picker accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie aus, welcher Shortcut nach dem Stoppen der Aufnahme ausgeführt wird"
+    "settings.postRecording.shortcut.picker.accessibility.hint": {
+      "comment": "Shortcut picker accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie aus, welcher Shortcut nach dem Stoppen der Aufnahme ausgeführt wird"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose a shortcut that will receive the transcript file path as input"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a shortcut that will receive the transcript file path as input"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecciona qué atajo ejecutar después de detener la grabación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona qué atajo ejecutar después de detener la grabación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez quel raccourci exécuter après l'arrêt de l'enregistrement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez quel raccourci exécuter après l'arrêt de l'enregistrement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "録音停止後に実行するショートカットを選択します"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音停止後に実行するショートカットを選択します"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择停止录音后要运行的快捷指令"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择停止录音后要运行的快捷指令"
           }
         }
       }
     },
-    "settings.postRecording.shortcut.picker.accessibility.label" : {
-      "comment" : "Shortcut picker accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shortcut auswählen"
+    "settings.postRecording.shortcut.picker.accessibility.label": {
+      "comment": "Shortcut picker accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut auswählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shortcut"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar atajo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar atajo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner un raccourci"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner un raccourci"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ショートカットを選択"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットを選択"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择快捷指令"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择快捷指令"
           }
         }
       }
     },
-    "settings.postRecording.shortcut.picker.label" : {
-      "comment" : "Shortcut picker label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shortcut"
+    "settings.postRecording.shortcut.picker.label": {
+      "comment": "Shortcut picker label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shortcut:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atajo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atajo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raccourci"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raccourci"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ショートカット"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカット"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "快捷指令"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷指令"
           }
         }
       }
     },
-    "settings.postRecording.shortcut.placeholder" : {
-      "comment" : "Shortcut picker placeholder",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shortcut auswählen…"
+    "settings.postRecording.shortcut.placeholder": {
+      "comment": "Shortcut picker placeholder",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut auswählen…"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select a shortcut..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a shortcut..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar atajo…"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar atajo…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner un raccourci…"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner un raccourci…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ショートカットを選択…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットを選択…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择快捷指令…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择快捷指令…"
           }
         }
       }
     },
-    "settings.silenceDetection.autoPause.accessibility.hint" : {
-      "comment" : "Auto-pause accessibility hint",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie aus, wie lange die Stille dauern soll, bevor automatisch pausiert wird, oder wählen Sie Nie zum Deaktivieren"
+    "settings.silenceDetection.autoPause.accessibility.hint": {
+      "comment": "Auto-pause accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie aus, wie lange die Stille dauern soll, bevor automatisch pausiert wird, oder wählen Sie Nie zum Deaktivieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatically pause recording after continuous silence. Recording will auto-resume when audio is detected"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically pause recording after continuous silence. Recording will auto-resume when audio is detected"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecciona cuánto tiempo de silencio antes de pausar automáticamente, o elige Nunca para deshabilitar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona cuánto tiempo de silencio antes de pausar automáticamente, o elige Nunca para deshabilitar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez la durée du silence avant la pause automatique, ou choisissez Jamais pour désactiver"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez la durée du silence avant la pause automatique, ou choisissez Jamais pour désactiver"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動的に一時停止するまでの無音時間を選択するか、無効にするには「しない」を選択します"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動的に一時停止するまでの無音時間を選択するか、無効にするには「しない」を選択します"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择自动暂停前的静音时长，或选择\"从不\"以禁用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择自动暂停前的静音时长，或选择\"从不\"以禁用"
           }
         }
       }
     },
-    "settings.silenceDetection.autoPause.accessibility.label" : {
-      "comment" : "Auto-pause accessibility label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatische Pause nach Stille"
+    "settings.silenceDetection.autoPause.accessibility.label": {
+      "comment": "Auto-pause accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatische Pause nach Stille"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-pause after silence"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-pause after silence"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausa automática después del silencio"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausa automática después del silencio"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause automatique après silence"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause automatique après silence"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無音後に自動一時停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無音後に自動一時停止"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "静音后自动暂停"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静音后自动暂停"
           }
         }
       }
     },
-    "settings.silenceDetection.autoPause.label" : {
-      "comment" : "Auto-pause picker label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatische Pause nach Stille"
+    "settings.silenceDetection.autoPause.label": {
+      "comment": "Auto-pause picker label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatische Pause nach Stille"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-pause after silence:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-pause after silence:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausa automática después del silencio"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausa automática después del silencio"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pause automatique après silence"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause automatique après silence"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無音後に自動一時停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無音後に自動一時停止"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "静音后自动暂停"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静音后自动暂停"
           }
         }
       }
     },
-    "settings.silenceDetection.header" : {
-      "comment" : "Silence detection section header",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stille-Erkennung"
+    "settings.silenceDetection.header": {
+      "comment": "Silence detection section header",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stille-Erkennung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Silence Detection"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Silence Detection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detección de silencio"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detección de silencio"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Détection du silence"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détection du silence"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無音検出"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無音検出"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "静音检测"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静音检测"
           }
         }
       }
     },
-    "settings.silenceDetection.helpText" : {
-      "comment" : "Silence detection help text",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausiert die Aufnahme automatisch nach dem angegebenen Stillezeitraum. Nützlich zum Pausieren während langer Pausen in Gesprächen."
+    "settings.silenceDetection.helpText": {
+      "comment": "Silence detection help text",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausiert die Aufnahme automatisch nach dem angegebenen Stillezeitraum. Nützlich zum Pausieren während langer Pausen in Gesprächen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatically pause recording after continuous silence. Recording will auto-resume when audio is detected."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically pause recording after continuous silence. Recording will auto-resume when audio is detected."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pausa automáticamente la grabación después del período de silencio especificado. Útil para pausar durante largas pausas en las conversaciones."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausa automáticamente la grabación después del período de silencio especificado. Útil para pausar durante largas pausas en las conversaciones."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Met automatiquement en pause l'enregistrement après la période de silence spécifiée. Utile pour faire une pause pendant de longues pauses dans les conversations."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Met automatiquement en pause l'enregistrement après la période de silence spécifiée. Utile pour faire une pause pendant de longues pauses dans les conversations."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "指定された無音期間の後、録音を自動的に一時停止します。会話の長い休止中に一時停止するのに便利です。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指定された無音期間の後、録音を自動的に一時停止します。会話の長い休止中に一時停止するのに便利です。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在指定的静音期后自动暂停录音。适用于在对话中的长时间停顿期间暂停。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在指定的静音期后自动暂停录音。适用于在对话中的长时间停顿期间暂停。"
           }
         }
       }
     },
-    "silenceThreshold.fiveMinutes" : {
-      "comment" : "5 minutes threshold",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "5 Minuten"
+    "silenceThreshold.fiveMinutes": {
+      "comment": "5 minutes threshold",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 Minuten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "5 minutes"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 minutes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "5 minutos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 minutos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "5 minutes"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 minutes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "5分"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5分"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "5分钟"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5分钟"
           }
         }
       }
     },
-    "silenceThreshold.never" : {
-      "comment" : "Never threshold",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie"
+    "silenceThreshold.never": {
+      "comment": "Never threshold",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Never"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Never"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nunca"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nunca"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jamais"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jamais"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "なし"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "なし"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从不"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从不"
           }
         }
       }
     },
-    "silenceThreshold.tenMinutes" : {
-      "comment" : "10 minutes threshold",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10 Minuten"
+    "silenceThreshold.tenMinutes": {
+      "comment": "10 minutes threshold",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 Minuten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10 minutes"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 minutes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10 minutos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 minutos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10 minutes"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 minutes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10分"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10分"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10分钟"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10分钟"
           }
         }
       }
     },
-    "silenceThreshold.twoMinutes" : {
-      "comment" : "2 minutes threshold",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2 Minuten"
+    "silenceThreshold.twoMinutes": {
+      "comment": "2 minutes threshold",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 Minuten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2 minutes"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 minutes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2 minutos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 minutos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2 minutes"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 minutes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2分"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2分"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2分钟"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2分钟"
           }
         }
       }
     },
-    "transcript.header.dateLabel" : {
-      "comment" : "Date label in transcript header",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datum: "
+    "transcript.header.dateLabel": {
+      "comment": "Date label in transcript header",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datum: "
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date: "
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date: "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fecha: "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fecha: "
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date : "
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date : "
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日付："
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日付："
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日期："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日期："
           }
         }
       }
     },
-    "transcript.header.separator" : {
-      "comment" : "Separator line in transcript header",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "================================================================================"
+    "transcript.header.separator": {
+      "comment": "Separator line in transcript header",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "================================================================================"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "================================================================================"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "================================================================================"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "================================================================================"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "================================================================================"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "================================================================================"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "================================================================================"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "================================================================================"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "================================================================================"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "================================================================================"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "================================================================================"
           }
         }
       }
     },
-    "transcript.header.title" : {
-      "comment" : "Transcript file header title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive - Anruftranskription"
+    "transcript.header.title": {
+      "comment": "Transcript file header title",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive - Anruftranskription"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive - Call Transcription Transcript"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive - Call Transcription Transcript"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive - Transcripción de llamadas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive - Transcripción de llamadas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive - Transcription d'appels"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive - Transcription d'appels"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive - 通話文字起こし"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive - 通話文字起こし"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Olive - 通话转录"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olive - 通话转录"
           }
         }
       }
     },
-    "transcript.header.titleLabel" : {
-      "comment" : "Title label in transcript header",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Titel: "
+    "transcript.header.titleLabel": {
+      "comment": "Title label in transcript header",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titel: "
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Title: "
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Title: "
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Título: "
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Título: "
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Titre : "
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titre : "
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タイトル："
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイトル："
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "标题："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标题："
           }
         }
       }
     },
-    "error.alreadyPaused.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording is already paused"
+    "error.alreadyPaused.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording is already paused"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La grabación ya está pausada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'enregistrement est déjà en pause"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme ist bereits pausiert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音は既に一時停止中です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音已暂停"
+          }
         }
       }
     },
-    "error.alreadyPaused.failureReason" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The recording is already in a paused state"
+    "error.alreadyPaused.failureReason": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The recording is already in a paused state"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La grabación ya se encuentra en estado pausado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'enregistrement est déjà dans un état de pause"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Aufnahme befindet sich bereits im pausierten Zustand"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音は既に一時停止状態です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音已处于暂停状态"
           }
         }
       }
     },
-    "error.alreadyPaused.recoverySuggestion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resume the recording before attempting to pause again"
+    "error.alreadyPaused.recoverySuggestion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume the recording before attempting to pause again"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanude la grabación antes de intentar pausar nuevamente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprendre l'enregistrement avant de tenter de le mettre en pause à nouveau"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setzen Sie die Aufnahme fort, bevor Sie erneut pausieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再度一時停止する前に録音を再開してください"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在尝试再次暂停之前请恢复录音"
           }
         }
       }
     },
-    "error.alreadyRecording.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording is already in progress"
+    "error.alreadyRecording.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording is already in progress"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La grabación ya está en progreso"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'enregistrement est déjà en cours"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme läuft bereits"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音は既に進行中です"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音已在进行中"
+          }
         }
       }
     },
-    "error.alreadyRecording.failureReason" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A recording session is already active"
+    "error.alreadyRecording.failureReason": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A recording session is already active"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ya hay una sesión de grabación activa"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une session d'enregistrement est déjà active"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Aufnahmesitzung ist bereits aktiv"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音セッションは既にアクティブです"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音会话已处于活动状态"
+          }
         }
       }
     },
-    "error.alreadyRecording.recoverySuggestion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop the current recording before starting a new one"
+    "error.alreadyRecording.recoverySuggestion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop the current recording before starting a new one"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detenga la grabación actual antes de iniciar una nueva"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter l'enregistrement actuel avant d'en démarrer un nouveau"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stoppen Sie die aktuelle Aufnahme, bevor Sie eine neue starten"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しい録音を開始する前に現在の録音を停止してください"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在开始新录音之前请停止当前录音"
+          }
         }
       }
     },
-    "error.invalidCallbackScheme.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid callback URL scheme: %@"
+    "error.invalidCallbackScheme.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid callback URL scheme: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquema de URL de callback inválido: %@"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schéma d'URL de callback invalide : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiges Callback-URL-Schema: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なコールバックURLスキーム：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的回调URL方案：%@"
+          }
         }
       }
     },
-    "error.invalidCallbackScheme.failureReason" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The callback URL uses a disallowed scheme: %@"
+    "error.invalidCallbackScheme.failureReason": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The callback URL uses a disallowed scheme: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La URL de callback utiliza un esquema no permitido: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'URL de callback utilise un schéma non autorisé : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Callback-URL verwendet ein nicht zulässiges Schema: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コールバックURLは許可されていないスキームを使用しています：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回调URL使用了不允许的方案：%@"
           }
         }
       }
     },
-    "error.invalidCallbackScheme.recoverySuggestion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use a safe callback scheme like shortcuts://, http://, or https://"
+    "error.invalidCallbackScheme.recoverySuggestion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use a safe callback scheme like shortcuts://, http://, or https://"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use un esquema de callback seguro como shortcuts://, http:// o https://"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser un schéma de callback sécurisé comme shortcuts://, http:// ou https://"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden Sie ein sicheres Callback-Schema wie shortcuts://, http:// oder https://"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "shortcuts://、http://、またはhttps://などの安全なコールバックスキームを使用してください"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请使用安全的回调方案，如shortcuts://、http://或https://"
           }
         }
       }
     },
-    "error.invalidFilenameTemplate.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid filename template: %@"
+    "error.invalidFilenameTemplate.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid filename template: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plantilla de nombre de archivo inválida: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modèle de nom de fichier invalide : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige Dateinamenvorlage: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なファイル名テンプレート：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的文件名模板：%@"
           }
         }
       }
     },
-    "error.invalidFilenameTemplate.failureReason" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The filename template contains invalid characters or path separators: %@"
+    "error.invalidFilenameTemplate.failureReason": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The filename template contains invalid characters or path separators: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La plantilla de nombre de archivo contiene caracteres inválidos o separadores de ruta: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le modèle de nom de fichier contient des caractères invalides ou des séparateurs de chemin : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Dateinamenvorlage enthält ungültige Zeichen oder Pfadtrennzeichen: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル名テンプレートに無効な文字またはパス区切り文字が含まれています：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件名模板包含无效字符或路径分隔符：%@"
           }
         }
       }
     },
-    "error.invalidFilenameTemplate.recoverySuggestion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ensure the template contains no path separators (/ or \\) or traversal patterns (../)"
+    "error.invalidFilenameTemplate.recoverySuggestion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ensure the template contains no path separators (/ or \\) or traversal patterns (../)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asegúrese de que la plantilla no contenga separadores de ruta (/ o \\) ni patrones de recorrido (../)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assurez-vous que le modèle ne contient pas de séparateurs de chemin (/ ou \\) ni de motifs de parcours (../)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stellen Sie sicher, dass die Vorlage keine Pfadtrennzeichen (/ oder \\) oder Traversierungsmuster (../) enthält"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テンプレートにパス区切り文字（/または\\）やトラバーサルパターン（../）が含まれていないことを確認してください"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确保模板不包含路径分隔符（/或\\）或遍历模式（../）"
           }
         }
       }
     },
-    "error.invalidURLAction.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid URL action: %@"
+    "error.invalidURLAction.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid URL action: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acción de URL inválida: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Action d'URL invalide : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültige URL-Aktion: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なURLアクション：%@"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的URL操作：%@"
+          }
         }
       }
     },
-    "error.invalidURLAction.failureReason" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The URL contains an unsupported action: %@"
+    "error.invalidURLAction.failureReason": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The URL contains an unsupported action: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La URL contiene una acción no compatible: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'URL contient une action non prise en charge : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die URL enthält eine nicht unterstützte Aktion: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URLにサポートされていないアクションが含まれています：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL包含不支持的操作：%@"
           }
         }
       }
     },
-    "error.invalidURLAction.recoverySuggestion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use one of the supported actions: start, stop, pause, resume"
+    "error.invalidURLAction.recoverySuggestion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use one of the supported actions: start, stop, pause, resume"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use una de las acciones compatibles: start, stop, pause, resume"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser l'une des actions prises en charge : start, stop, pause, resume"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden Sie eine der unterstützten Aktionen: start, stop, pause, resume"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サポートされているアクションのいずれかを使用してください：start、stop、pause、resume"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请使用支持的操作之一：start、stop、pause、resume"
+          }
         }
       }
     },
-    "error.invalidURLHost.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid URL host: %@"
+    "error.invalidURLHost.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid URL host: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Host de URL inválido: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hôte d'URL invalide : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger URL-Host: %@"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なURLホスト：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的URL主机：%@"
+          }
         }
       }
     },
-    "error.invalidURLHost.failureReason" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The URL host should be 'x-callback-url' but was: %@"
+    "error.invalidURLHost.failureReason": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The URL host should be 'x-callback-url' but was: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El host de la URL debe ser 'x-callback-url' pero era: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'hôte de l'URL doit être 'x-callback-url' mais était : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der URL-Host sollte 'x-callback-url' sein, war aber: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URLホストは'x-callback-url'である必要がありますが、次のようになっていました：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL主机应为'x-callback-url'，但实际为：%@"
           }
         }
       }
     },
-    "error.invalidURLHost.recoverySuggestion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use the x-callback-url host: olive://x-callback-url/action"
+    "error.invalidURLHost.recoverySuggestion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the x-callback-url host: olive://x-callback-url/action"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use el host x-callback-url: olive://x-callback-url/action"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser l'hôte x-callback-url : olive://x-callback-url/action"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden Sie den x-callback-url-Host: olive://x-callback-url/action"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "x-callback-urlホストを使用してください：olive://x-callback-url/action"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请使用x-callback-url主机：olive://x-callback-url/action"
           }
         }
       }
     },
-    "error.invalidURLScheme.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid URL scheme: %@"
+    "error.invalidURLScheme.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid URL scheme: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquema de URL inválido: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schéma d'URL invalide : %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiges URL-Schema: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なURLスキーム：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的URL方案：%@"
           }
         }
       }
     },
-    "error.invalidURLScheme.failureReason" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The URL scheme should be 'olive' but was: %@"
+    "error.invalidURLScheme.failureReason": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The URL scheme should be 'olive' but was: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El esquema de la URL debe ser 'olive' pero era: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le schéma de l'URL doit être 'olive' mais était : %@"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das URL-Schema sollte 'olive' sein, war aber: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URLスキームは'olive'である必要がありますが、次のようになっていました：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL方案应为'olive'，但实际为：%@"
+          }
         }
       }
     },
-    "error.invalidURLScheme.recoverySuggestion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use the olive:// URL scheme"
+    "error.invalidURLScheme.recoverySuggestion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the olive:// URL scheme"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use el esquema de URL olive://"
           }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser le schéma d'URL olive://"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden Sie das URL-Schema olive://"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "olive:// URLスキームを使用してください"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请使用olive:// URL方案"
+          }
         }
       }
     },
-    "error.missingURLAction.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Missing URL action"
+    "error.missingURLAction.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Missing URL action"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falta la acción de URL"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Action d'URL manquante"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL-Aktion fehlt"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URLアクションがありません"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少URL操作"
+          }
         }
       }
     },
-    "error.missingURLAction.failureReason" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The URL does not specify an action to perform"
+    "error.missingURLAction.failureReason": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The URL does not specify an action to perform"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La URL no especifica una acción a realizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'URL ne spécifie pas d'action à effectuer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die URL gibt keine auszuführende Aktion an"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URLに実行するアクションが指定されていません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL未指定要执行的操作"
+          }
         }
       }
     },
-    "error.missingURLAction.recoverySuggestion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Include an action in the URL path: olive://x-callback-url/start"
+    "error.missingURLAction.recoverySuggestion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include an action in the URL path: olive://x-callback-url/start"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incluya una acción en la ruta de la URL: olive://x-callback-url/start"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inclure une action dans le chemin de l'URL : olive://x-callback-url/start"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fügen Sie eine Aktion im URL-Pfad hinzu: olive://x-callback-url/start"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URLパスにアクションを含めてください：olive://x-callback-url/start"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在URL路径中包含操作：olive://x-callback-url/start"
+          }
         }
       }
     },
-    "url.recording.defaultTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recording"
+    "url.recording.defaultTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录音"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }


### PR DESCRIPTION
## Summary

Adds 125 missing translations to the localization catalog across 5 languages (Spanish, French, German, Japanese, and Simplified Chinese).

## Changes

- Added translations for 25 localization keys across 5 target languages
- Each language now has complete translations for all 226 keys
- All translations are professionally crafted and contextually appropriate for a macOS application
- Format placeholders (%@) are consistently preserved across all translations

## Translation Coverage

**Keys translated (25 per language):**
- `error.alreadyPaused.*` (description, failureReason, recoverySuggestion)
- `error.alreadyRecording.*` (description, failureReason, recoverySuggestion)
- `error.invalidCallbackScheme.*` (description, failureReason, recoverySuggestion)
- `error.invalidFilenameTemplate.*` (description, failureReason, recoverySuggestion)
- `error.invalidURLAction.*` (description, failureReason, recoverySuggestion)
- `error.invalidURLHost.*` (description, failureReason, recoverySuggestion)
- `error.invalidURLScheme.*` (description, failureReason, recoverySuggestion)
- `error.missingURLAction.*` (description, failureReason, recoverySuggestion)
- `url.recording.defaultTitle`

**Languages completed:**
- Spanish (es): 25 translations
- French (fr): 25 translations
- German (de): 25 translations
- Japanese (ja): 25 translations
- Simplified Chinese (zh-Hans): 25 translations

## Validation

Validation script confirms all checks pass:
```
✅ All 226 keys have complete translations
✅ No placeholder values found
✅ All format placeholders are consistent
✅ 226 keys × 6 languages = 1356 string units validated
```

## Testing

- Ran `scripts/validate_localizations.py` - all validations passed
- Verified all 125 previously missing translations are now present
- Confirmed format placeholders are consistent across all languages
- Ensured translations maintain professional tone appropriate for macOS application

## Related Issue

Closes #153